### PR TITLE
Ensure hof is compatible with browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,13 @@
     "hmpo-template-mixins": "^1.1.0",
     "i18n-future": "^0.1.4",
     "i18n-lookup": "^0.1.0"
+  },
+  "browser": {
+    "hmpo-form-wizard": false,
+    "hmpo-govuk-template": false,
+    "hmpo-model": false,
+    "hmpo-template-mixins": false,
+    "i18n-future": false,
+    "i18n-lookup": false
   }
 }


### PR DESCRIPTION
Using the browser field disable all modules other than toolkit this ensures that when browserify runs it doesn't try to bundle up lots of packages that are not required.
