### PR TITLE
Remove i18n-lookup from HOF.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ HOF comprises the following modules.
  * [hmpo-template-mixins](https://github.com/UKHomeOffice/passports-template-mixins)
  * [hof-controllers](https://github.com/UKHomeOffice/hof-controllers)
  * [i18n-future](https://github.com/lennym/i18n-future)
- * [i18n-lookup](https://github.com/UKHomeOffice/i18n-lookup)
 
 And each module is available as a property of `hof`
 
@@ -37,5 +36,4 @@ var Model = hof.Model;
 var mixins = hof.mixins;
 var controllers = hof.controllers;
 var i18n = hof.i18n;
-var i18nLookup = hof.i18nLookup;
 ```

--- a/index.js
+++ b/index.js
@@ -5,8 +5,7 @@ var hof = {
   Model: require('hmpo-model'),
   mixins: require('hmpo-template-mixins'),
   controllers: require('hof-controllers'),
-  i18n: require('i18n-future'),
-  i18nLookup: require('i18n-lookup')
+  i18n: require('i18n-future')
 };
 
 module.exports = hof;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,57 +1,57 @@
 {
   "name": "hof",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "dependencies": {
     "hmpo-form-wizard": {
-      "version": "3.2.0",
-      "from": "hmpo-form-wizard@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/hmpo-form-wizard/-/hmpo-form-wizard-3.2.0.tgz",
+      "version": "3.3.0",
+      "from": "https://registry.npmjs.org/hmpo-form-wizard/-/hmpo-form-wizard-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/hmpo-form-wizard/-/hmpo-form-wizard-3.3.0.tgz",
       "dependencies": {
         "cookie-parser": {
-          "version": "1.4.0",
-          "from": "cookie-parser@>=1.3.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.0.tgz",
+          "version": "1.4.1",
+          "from": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.1.tgz",
           "dependencies": {
             "cookie": {
-              "version": "0.2.2",
-              "from": "cookie@0.2.2",
-              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.2.2.tgz"
+              "version": "0.2.3",
+              "from": "https://registry.npmjs.org/cookie/-/cookie-0.2.3.tgz",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.2.3.tgz"
             },
             "cookie-signature": {
               "version": "1.0.6",
-              "from": "cookie-signature@1.0.6",
+              "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
               "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
             }
           }
         },
         "csrf": {
           "version": "2.0.7",
-          "from": "csrf@>=2.0.6 <3.0.0",
+          "from": "https://registry.npmjs.org/csrf/-/csrf-2.0.7.tgz",
           "resolved": "https://registry.npmjs.org/csrf/-/csrf-2.0.7.tgz",
           "dependencies": {
             "base64-url": {
               "version": "1.2.1",
-              "from": "base64-url@1.2.1",
+              "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
             },
             "rndm": {
               "version": "1.1.1",
-              "from": "rndm@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/rndm/-/rndm-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.1.1.tgz"
             },
             "scmp": {
               "version": "1.0.0",
-              "from": "scmp@1.0.0",
+              "from": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz"
             },
             "uid-safe": {
               "version": "1.1.0",
-              "from": "uid-safe@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.1.0.tgz",
               "dependencies": {
                 "native-or-bluebird": {
                   "version": "1.1.2",
-                  "from": "native-or-bluebird@>=1.1.2 <1.2.0",
+                  "from": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz"
                 }
               }
@@ -60,229 +60,224 @@
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.1.2 <3.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "depd": {
           "version": "1.1.0",
-          "from": "depd@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "express": {
-          "version": "4.13.3",
-          "from": "express@>=4.12.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/express/-/express-4.13.3.tgz",
+          "version": "4.13.4",
+          "from": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
           "dependencies": {
             "accepts": {
               "version": "1.2.13",
-              "from": "accepts@>=1.2.12 <1.3.0",
+              "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
               "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
               "dependencies": {
                 "mime-types": {
-                  "version": "2.1.8",
-                  "from": "mime-types@>=2.1.6 <2.2.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
+                  "version": "2.1.9",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.20.0",
-                      "from": "mime-db@>=1.20.0 <1.21.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
+                      "version": "1.21.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
                     }
                   }
                 },
                 "negotiator": {
                   "version": "0.5.3",
-                  "from": "negotiator@0.5.3",
+                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
                 }
               }
             },
             "array-flatten": {
               "version": "1.1.1",
-              "from": "array-flatten@1.1.1",
+              "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
             },
             "content-disposition": {
-              "version": "0.5.0",
-              "from": "content-disposition@0.5.0",
-              "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz"
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
             },
             "content-type": {
               "version": "1.0.1",
-              "from": "content-type@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
             },
             "cookie": {
-              "version": "0.1.3",
-              "from": "cookie@0.1.3",
-              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
+              "version": "0.1.5",
+              "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz"
             },
             "cookie-signature": {
               "version": "1.0.6",
-              "from": "cookie-signature@1.0.6",
+              "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
               "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
             },
-            "depd": {
-              "version": "1.0.1",
-              "from": "depd@>=1.0.1 <1.1.0",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
-            },
             "escape-html": {
-              "version": "1.0.2",
-              "from": "escape-html@1.0.2",
-              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
             },
             "etag": {
               "version": "1.7.0",
-              "from": "etag@>=1.7.0 <1.8.0",
+              "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
               "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
             },
             "finalhandler": {
-              "version": "0.4.0",
-              "from": "finalhandler@0.4.0",
-              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
+              "version": "0.4.1",
+              "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
               "dependencies": {
                 "unpipe": {
                   "version": "1.0.0",
-                  "from": "unpipe@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                 }
               }
             },
             "fresh": {
               "version": "0.3.0",
-              "from": "fresh@0.3.0",
+              "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
             },
             "merge-descriptors": {
-              "version": "1.0.0",
-              "from": "merge-descriptors@1.0.0",
-              "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz"
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
             },
             "methods": {
-              "version": "1.1.1",
-              "from": "methods@>=1.1.1 <1.2.0",
-              "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
             },
             "on-finished": {
               "version": "2.3.0",
-              "from": "on-finished@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "dependencies": {
                 "ee-first": {
                   "version": "1.1.1",
-                  "from": "ee-first@1.1.1",
+                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                 }
               }
             },
             "parseurl": {
-              "version": "1.3.0",
-              "from": "parseurl@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+              "version": "1.3.1",
+              "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
             },
             "path-to-regexp": {
               "version": "0.1.7",
-              "from": "path-to-regexp@0.1.7",
+              "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
               "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
             },
             "proxy-addr": {
-              "version": "1.0.9",
-              "from": "proxy-addr@>=1.0.8 <1.1.0",
-              "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.9.tgz",
+              "version": "1.0.10",
+              "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
               "dependencies": {
                 "forwarded": {
                   "version": "0.1.0",
-                  "from": "forwarded@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
                 },
                 "ipaddr.js": {
-                  "version": "1.0.4",
-                  "from": "ipaddr.js@1.0.4",
-                  "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.4.tgz"
+                  "version": "1.0.5",
+                  "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
                 }
               }
             },
             "qs": {
               "version": "4.0.0",
-              "from": "qs@4.0.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
             },
             "range-parser": {
               "version": "1.0.3",
-              "from": "range-parser@>=1.0.2 <1.1.0",
+              "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
             },
             "send": {
-              "version": "0.13.0",
-              "from": "send@0.13.0",
-              "resolved": "https://registry.npmjs.org/send/-/send-0.13.0.tgz",
+              "version": "0.13.1",
+              "from": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
               "dependencies": {
                 "destroy": {
-                  "version": "1.0.3",
-                  "from": "destroy@1.0.3",
-                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
                 },
                 "http-errors": {
                   "version": "1.3.1",
-                  "from": "http-errors@>=1.3.1 <1.4.0",
+                  "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "mime": {
                   "version": "1.3.4",
-                  "from": "mime@1.3.4",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                 },
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 },
                 "statuses": {
                   "version": "1.2.1",
-                  "from": "statuses@>=1.2.1 <1.3.0",
+                  "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                 }
               }
             },
             "serve-static": {
-              "version": "1.10.0",
-              "from": "serve-static@>=1.10.0 <1.11.0",
-              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.0.tgz"
+              "version": "1.10.2",
+              "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz",
+              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz"
             },
             "type-is": {
-              "version": "1.6.10",
-              "from": "type-is@>=1.6.6 <1.7.0",
-              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.10.tgz",
+              "version": "1.6.11",
+              "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.11.tgz",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.11.tgz",
               "dependencies": {
                 "media-typer": {
                   "version": "0.3.0",
-                  "from": "media-typer@0.3.0",
+                  "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                 },
                 "mime-types": {
-                  "version": "2.1.8",
-                  "from": "mime-types@>=2.1.6 <2.2.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
+                  "version": "2.1.9",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.20.0",
-                      "from": "mime-db@>=1.20.0 <1.21.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
+                      "version": "1.21.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
                     }
                   }
                 }
@@ -290,125 +285,125 @@
             },
             "utils-merge": {
               "version": "1.0.0",
-              "from": "utils-merge@1.0.0",
+              "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
             },
             "vary": {
               "version": "1.0.1",
-              "from": "vary@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
             }
           }
         },
         "express-session": {
-          "version": "1.12.1",
-          "from": "express-session@>=1.10.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.12.1.tgz",
+          "version": "1.13.0",
+          "from": "https://registry.npmjs.org/express-session/-/express-session-1.13.0.tgz",
+          "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.13.0.tgz",
           "dependencies": {
             "cookie": {
               "version": "0.2.3",
-              "from": "cookie@0.2.3",
+              "from": "https://registry.npmjs.org/cookie/-/cookie-0.2.3.tgz",
               "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.2.3.tgz"
             },
             "cookie-signature": {
               "version": "1.0.6",
-              "from": "cookie-signature@1.0.6",
+              "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
               "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
             },
             "crc": {
-              "version": "3.3.0",
-              "from": "crc@3.3.0",
-              "resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz"
+              "version": "3.4.0",
+              "from": "https://registry.npmjs.org/crc/-/crc-3.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.0.tgz"
             },
             "on-headers": {
               "version": "1.0.1",
-              "from": "on-headers@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
             },
             "parseurl": {
-              "version": "1.3.0",
-              "from": "parseurl@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+              "version": "1.3.1",
+              "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
             },
             "uid-safe": {
               "version": "2.0.0",
-              "from": "uid-safe@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
               "dependencies": {
                 "base64-url": {
                   "version": "1.2.1",
-                  "from": "base64-url@1.2.1",
+                  "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
                 }
               }
             },
             "utils-merge": {
               "version": "1.0.0",
-              "from": "utils-merge@1.0.0",
+              "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
             }
           }
         },
         "hmpo-form-controller": {
           "version": "0.5.0",
-          "from": "hmpo-form-controller@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/hmpo-form-controller/-/hmpo-form-controller-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/hmpo-form-controller/-/hmpo-form-controller-0.5.0.tgz",
           "dependencies": {
             "moment": {
-              "version": "2.10.6",
-              "from": "moment@>=2.9.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
+              "version": "2.11.1",
+              "from": "https://registry.npmjs.org/moment/-/moment-2.11.1.tgz",
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.1.tgz"
             }
           }
         },
         "hmpo-model": {
           "version": "0.0.0",
-          "from": "hmpo-model@0.0.0",
+          "from": "https://registry.npmjs.org/hmpo-model/-/hmpo-model-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/hmpo-model/-/hmpo-model-0.0.0.tgz",
           "dependencies": {
             "concat-stream": {
               "version": "1.5.1",
-              "from": "concat-stream@>=1.4.7 <2.0.0",
+              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "typedarray": {
                   "version": "0.0.6",
-                  "from": "typedarray@>=0.0.5 <0.1.0",
+                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
-                  "version": "2.0.4",
-                  "from": "readable-stream@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+                  "version": "2.0.5",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -419,117 +414,122 @@
         },
         "hogan.js": {
           "version": "3.0.2",
-          "from": "hogan.js@>=3.0.2 <4.0.0",
+          "from": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
           "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
           "dependencies": {
             "nopt": {
               "version": "1.0.10",
-              "from": "nopt@1.0.10",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "mkdirp": {
               "version": "0.3.0",
-              "from": "mkdirp@0.3.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
             }
           }
         },
+        "i18n-lookup": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/i18n-lookup/-/i18n-lookup-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/i18n-lookup/-/i18n-lookup-0.1.0.tgz"
+        },
         "underscore": {
           "version": "1.8.3",
-          "from": "underscore@>=1.8.2 <2.0.0",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
         }
       }
     },
     "hmpo-frontend-toolkit": {
-      "version": "1.5.0",
-      "from": "hmpo-frontend-toolkit@>=1.5.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/hmpo-frontend-toolkit/-/hmpo-frontend-toolkit-1.5.0.tgz",
+      "version": "2.0.0",
+      "from": "https://registry.npmjs.org/hmpo-frontend-toolkit/-/hmpo-frontend-toolkit-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/hmpo-frontend-toolkit/-/hmpo-frontend-toolkit-2.0.0.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "browserify": {
           "version": "4.2.3",
-          "from": "browserify@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/browserify/-/browserify-4.2.3.tgz",
           "resolved": "https://registry.npmjs.org/browserify/-/browserify-4.2.3.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.8.4",
-              "from": "JSONStream@>=0.8.3 <0.9.0",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.2.7 <3.0.0",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "assert": {
               "version": "1.1.2",
-              "from": "assert@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz"
             },
             "browser-pack": {
               "version": "2.0.1",
-              "from": "browser-pack@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-2.0.1.tgz",
               "dependencies": {
                 "JSONStream": {
                   "version": "0.6.4",
-                  "from": "JSONStream@>=0.6.4 <0.7.0",
+                  "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.6.4.tgz",
                   "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.6.4.tgz",
                   "dependencies": {
                     "jsonparse": {
                       "version": "0.0.5",
-                      "from": "jsonparse@0.0.5",
+                      "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                     },
                     "through": {
                       "version": "2.2.7",
-                      "from": "through@>=2.2.7 <2.3.0",
+                      "from": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz"
                     }
                   }
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.3.4 <2.4.0",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 },
                 "combine-source-map": {
                   "version": "0.3.0",
-                  "from": "combine-source-map@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
                   "dependencies": {
                     "inline-source-map": {
                       "version": "0.3.1",
-                      "from": "inline-source-map@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                       "dependencies": {
                         "source-map": {
                           "version": "0.3.0",
-                          "from": "source-map@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "1.0.0",
-                              "from": "amdefine@>=0.0.4",
+                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                             }
                           }
@@ -538,17 +538,17 @@
                     },
                     "convert-source-map": {
                       "version": "0.3.5",
-                      "from": "convert-source-map@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
                       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "source-map@>=0.1.31 <0.2.0",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "1.0.0",
-                          "from": "amdefine@>=0.0.4",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                         }
                       }
@@ -558,118 +558,118 @@
               }
             },
             "browser-resolve": {
-              "version": "1.11.0",
-              "from": "browser-resolve@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.0.tgz",
+              "version": "1.11.1",
+              "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.1.tgz",
+              "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.1.tgz",
               "dependencies": {
                 "resolve": {
-                  "version": "1.1.6",
-                  "from": "resolve@1.1.6",
-                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+                  "version": "1.1.7",
+                  "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
                 }
               }
             },
             "browserify-zlib": {
               "version": "0.1.4",
-              "from": "browserify-zlib@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
               "dependencies": {
                 "pako": {
                   "version": "0.2.8",
-                  "from": "pako@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz",
                   "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
                 }
               }
             },
             "buffer": {
               "version": "2.8.2",
-              "from": "buffer@>=2.3.0 <3.0.0",
+              "from": "https://registry.npmjs.org/buffer/-/buffer-2.8.2.tgz",
               "resolved": "https://registry.npmjs.org/buffer/-/buffer-2.8.2.tgz",
               "dependencies": {
                 "base64-js": {
                   "version": "0.0.7",
-                  "from": "base64-js@0.0.7",
+                  "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.7.tgz"
                 },
                 "ieee754": {
                   "version": "1.1.6",
-                  "from": "ieee754@>=1.1.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
                 },
                 "is-array": {
                   "version": "1.0.1",
-                  "from": "is-array@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
                 }
               }
             },
             "builtins": {
               "version": "0.0.7",
-              "from": "builtins@>=0.0.3 <0.1.0",
+              "from": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
               "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
             },
             "commondir": {
               "version": "0.0.1",
-              "from": "commondir@0.0.1",
+              "from": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
             },
             "concat-stream": {
               "version": "1.4.10",
-              "from": "concat-stream@>=1.4.1 <1.5.0",
+              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
-                  "from": "typedarray@>=0.0.5 <0.1.0",
+                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 }
               }
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "console-browserify@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "date-now@>=0.1.4 <0.2.0",
+                  "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                 }
               }
             },
             "constants-browserify": {
               "version": "0.0.1",
-              "from": "constants-browserify@>=0.0.1 <0.1.0",
+              "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
             },
             "crypto-browserify": {
               "version": "2.1.10",
-              "from": "crypto-browserify@>=2.1.8 <3.0.0",
+              "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.10.tgz",
               "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.10.tgz",
               "dependencies": {
                 "ripemd160": {
                   "version": "0.2.0",
-                  "from": "ripemd160@0.2.0",
+                  "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
                 },
                 "sha.js": {
                   "version": "2.1.6",
-                  "from": "sha.js@2.1.6",
+                  "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.1.6.tgz",
                   "dependencies": {
                     "buffer": {
                       "version": "2.3.4",
-                      "from": "buffer@>=2.3.2 <2.4.0",
+                      "from": "https://registry.npmjs.org/buffer/-/buffer-2.3.4.tgz",
                       "resolved": "https://registry.npmjs.org/buffer/-/buffer-2.3.4.tgz",
                       "dependencies": {
                         "base64-js": {
                           "version": "0.0.8",
-                          "from": "base64-js@>=0.0.4 <0.1.0",
+                          "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
                           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
                         },
                         "ieee754": {
                           "version": "1.1.6",
-                          "from": "ieee754@>=1.1.1 <1.2.0",
+                          "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz",
                           "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
                         }
                       }
@@ -680,120 +680,120 @@
             },
             "deep-equal": {
               "version": "0.2.2",
-              "from": "deep-equal@>=0.2.1 <0.3.0",
+              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
             },
             "defined": {
               "version": "0.0.0",
-              "from": "defined@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
             },
             "deps-sort": {
               "version": "0.1.2",
-              "from": "deps-sort@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/deps-sort/-/deps-sort-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-0.1.2.tgz",
               "dependencies": {
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.3.4 <2.4.0",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 },
                 "JSONStream": {
                   "version": "0.6.4",
-                  "from": "JSONStream@>=0.6.4 <0.7.0",
+                  "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.6.4.tgz",
                   "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.6.4.tgz",
                   "dependencies": {
                     "jsonparse": {
                       "version": "0.0.5",
-                      "from": "jsonparse@0.0.5",
+                      "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                     },
                     "through": {
                       "version": "2.2.7",
-                      "from": "through@>=2.2.7 <2.3.0",
+                      "from": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz"
                     }
                   }
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
             "derequire": {
               "version": "0.8.0",
-              "from": "derequire@>=0.8.0 <0.9.0",
+              "from": "https://registry.npmjs.org/derequire/-/derequire-0.8.0.tgz",
               "resolved": "https://registry.npmjs.org/derequire/-/derequire-0.8.0.tgz",
               "dependencies": {
                 "estraverse": {
                   "version": "1.5.1",
-                  "from": "estraverse@>=1.5.0 <1.6.0",
+                  "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
                 },
                 "esrefactor": {
                   "version": "0.1.0",
-                  "from": "esrefactor@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/esrefactor/-/esrefactor-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/esrefactor/-/esrefactor-0.1.0.tgz",
                   "dependencies": {
                     "esprima": {
                       "version": "1.0.4",
-                      "from": "esprima@>=1.0.2 <1.1.0",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                     },
                     "estraverse": {
                       "version": "0.0.4",
-                      "from": "estraverse@>=0.0.4 <0.1.0",
+                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-0.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-0.0.4.tgz"
                     },
                     "escope": {
                       "version": "0.0.16",
-                      "from": "escope@>=0.0.13 <0.1.0",
+                      "from": "https://registry.npmjs.org/escope/-/escope-0.0.16.tgz",
                       "resolved": "https://registry.npmjs.org/escope/-/escope-0.0.16.tgz"
                     }
                   }
                 },
                 "esprima-fb": {
                   "version": "3001.1.0-dev-harmony-fb",
-                  "from": "esprima-fb@>=3001.1.0-dev-harmony-fb <3002.0.0",
+                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
                   "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
                 }
               }
             },
             "domain-browser": {
-              "version": "1.1.4",
-              "from": "domain-browser@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
+              "version": "1.1.7",
+              "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+              "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
             },
             "duplexer": {
               "version": "0.1.1",
-              "from": "duplexer@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
             },
             "events": {
               "version": "1.0.2",
-              "from": "events@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
             },
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.8 <3.3.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -802,56 +802,56 @@
             },
             "http-browserify": {
               "version": "1.7.0",
-              "from": "http-browserify@>=1.4.0 <2.0.0",
+              "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
               "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
               "dependencies": {
                 "Base64": {
                   "version": "0.2.1",
-                  "from": "Base64@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
                 }
               }
             },
             "https-browserify": {
               "version": "0.0.1",
-              "from": "https-browserify@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "insert-module-globals": {
               "version": "6.0.0",
-              "from": "insert-module-globals@>=6.0.0 <6.1.0",
+              "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.0.0.tgz",
               "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.0.0.tgz",
               "dependencies": {
                 "JSONStream": {
                   "version": "0.7.4",
-                  "from": "JSONStream@>=0.7.1 <0.8.0",
+                  "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
                   "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
                   "dependencies": {
                     "jsonparse": {
                       "version": "0.0.5",
-                      "from": "jsonparse@0.0.5",
+                      "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                     }
                   }
                 },
                 "lexical-scope": {
                   "version": "1.1.1",
-                  "from": "lexical-scope@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz",
                   "dependencies": {
                     "astw": {
                       "version": "2.0.0",
-                      "from": "astw@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
                       "dependencies": {
                         "acorn": {
                           "version": "1.2.2",
-                          "from": "acorn@>=1.0.3 <2.0.0",
+                          "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
                           "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                         }
                       }
@@ -860,76 +860,76 @@
                 },
                 "process": {
                   "version": "0.6.0",
-                  "from": "process@>=0.6.0 <0.7.0",
+                  "from": "https://registry.npmjs.org/process/-/process-0.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.3.4 <2.4.0",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "module-deps": {
               "version": "2.1.5",
-              "from": "module-deps@>=2.1.1 <2.2.0",
+              "from": "https://registry.npmjs.org/module-deps/-/module-deps-2.1.5.tgz",
               "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-2.1.5.tgz",
               "dependencies": {
                 "JSONStream": {
                   "version": "0.7.4",
-                  "from": "JSONStream@>=0.7.1 <0.8.0",
+                  "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
                   "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
                   "dependencies": {
                     "jsonparse": {
                       "version": "0.0.5",
-                      "from": "jsonparse@0.0.5",
+                      "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                     },
                     "through": {
                       "version": "2.3.8",
-                      "from": "through@>=2.2.7 <3.0.0",
+                      "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                     }
                   }
                 },
                 "browser-resolve": {
                   "version": "1.2.4",
-                  "from": "browser-resolve@>=1.2.4 <1.3.0",
+                  "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.2.4.tgz",
                   "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.2.4.tgz"
                 },
                 "detective": {
                   "version": "3.1.0",
-                  "from": "detective@>=3.1.0 <3.2.0",
+                  "from": "https://registry.npmjs.org/detective/-/detective-3.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/detective/-/detective-3.1.0.tgz",
                   "dependencies": {
                     "escodegen": {
                       "version": "1.1.0",
-                      "from": "escodegen@>=1.1.0 <1.2.0",
+                      "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
                       "dependencies": {
                         "esprima": {
                           "version": "1.0.4",
-                          "from": "esprima@>=1.0.4 <1.1.0",
+                          "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                         },
                         "estraverse": {
                           "version": "1.5.1",
-                          "from": "estraverse@>=1.5.0 <1.6.0",
+                          "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
                           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
                         },
                         "esutils": {
                           "version": "1.0.0",
-                          "from": "esutils@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
                         },
                         "source-map": {
                           "version": "0.1.43",
-                          "from": "source-map@>=0.1.30 <0.2.0",
+                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "1.0.0",
-                              "from": "amdefine@>=0.0.4",
+                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                             }
                           }
@@ -938,78 +938,78 @@
                     },
                     "esprima-fb": {
                       "version": "3001.1.0-dev-harmony-fb",
-                      "from": "esprima-fb@3001.1.0-dev-harmony-fb",
+                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
                       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
                     }
                   }
                 },
                 "duplexer2": {
                   "version": "0.0.2",
-                  "from": "duplexer2@0.0.2",
+                  "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.9 <0.1.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 },
                 "parents": {
                   "version": "0.0.2",
-                  "from": "parents@0.0.2",
+                  "from": "https://registry.npmjs.org/parents/-/parents-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.2.tgz"
                 },
                 "resolve": {
                   "version": "0.6.3",
-                  "from": "resolve@>=0.6.3 <0.7.0",
+                  "from": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
                   "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz"
                 },
                 "stream-combiner": {
                   "version": "0.1.0",
-                  "from": "stream-combiner@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.1.0.tgz",
                   "dependencies": {
                     "through": {
                       "version": "2.3.8",
-                      "from": "through@>=2.3.4 <2.4.0",
+                      "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                     }
                   }
                 },
                 "through2": {
                   "version": "0.4.2",
-                  "from": "through2@>=0.4.1 <0.5.0",
+                  "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.17 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "2.1.2",
-                      "from": "xtend@>=2.1.1 <2.2.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                       "dependencies": {
                         "object-keys": {
                           "version": "0.4.0",
-                          "from": "object-keys@>=0.4.0 <0.5.0",
+                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                         }
                       }
@@ -1020,193 +1020,193 @@
             },
             "os-browserify": {
               "version": "0.1.2",
-              "from": "os-browserify@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
             },
             "parents": {
               "version": "0.0.3",
-              "from": "parents@>=0.0.1 <0.1.0",
+              "from": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
               "dependencies": {
                 "path-platform": {
                   "version": "0.0.1",
-                  "from": "path-platform@>=0.0.1 <0.0.2",
+                  "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz"
                 }
               }
             },
             "path-browserify": {
               "version": "0.0.0",
-              "from": "path-browserify@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
             },
             "punycode": {
               "version": "1.2.4",
-              "from": "punycode@>=1.2.3 <1.3.0",
+              "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
             },
             "querystring-es3": {
               "version": "0.2.1",
-              "from": "querystring-es3@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.0.27-1 <2.0.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 }
               }
             },
             "resolve": {
               "version": "0.7.4",
-              "from": "resolve@>=0.7.1 <0.8.0",
+              "from": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
             },
             "shallow-copy": {
               "version": "0.0.1",
-              "from": "shallow-copy@0.0.1",
+              "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
             },
             "shell-quote": {
               "version": "0.0.1",
-              "from": "shell-quote@>=0.0.1 <0.1.0",
+              "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
             },
             "stream-browserify": {
               "version": "1.0.0",
-              "from": "stream-browserify@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
             },
             "stream-combiner": {
               "version": "0.0.4",
-              "from": "stream-combiner@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
             },
             "string_decoder": {
               "version": "0.0.1",
-              "from": "string_decoder@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.0.1.tgz"
             },
             "subarg": {
               "version": "0.0.1",
-              "from": "subarg@0.0.1",
+              "from": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
             "syntax-error": {
-              "version": "1.1.4",
-              "from": "syntax-error@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.4.tgz",
+              "version": "1.1.5",
+              "from": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.5.tgz",
+              "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.5.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "1.2.2",
-                  "from": "acorn@>=1.0.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                  "version": "2.7.0",
+                  "from": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
                 }
               }
             },
             "through2": {
               "version": "1.1.1",
-              "from": "through2@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
               "dependencies": {
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "timers-browserify": {
-              "version": "1.4.1",
-              "from": "timers-browserify@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz",
+              "version": "1.4.2",
+              "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+              "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
               "dependencies": {
                 "process": {
                   "version": "0.11.2",
-                  "from": "process@>=0.11.0 <0.12.0",
+                  "from": "https://registry.npmjs.org/process/-/process-0.11.2.tgz",
                   "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
                 }
               }
             },
             "tty-browserify": {
               "version": "0.0.0",
-              "from": "tty-browserify@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
             },
             "umd": {
               "version": "2.1.0",
-              "from": "umd@>=2.1.0 <2.2.0",
+              "from": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
               "dependencies": {
                 "rfile": {
                   "version": "1.0.0",
-                  "from": "rfile@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
                   "dependencies": {
                     "callsite": {
                       "version": "1.0.0",
-                      "from": "callsite@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                     },
                     "resolve": {
                       "version": "0.3.1",
-                      "from": "resolve@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
                     }
                   }
                 },
                 "ruglify": {
                   "version": "1.0.0",
-                  "from": "ruglify@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
                   "dependencies": {
                     "uglify-js": {
                       "version": "2.2.5",
-                      "from": "uglify-js@>=2.2.0 <2.3.0",
+                      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                       "dependencies": {
                         "source-map": {
                           "version": "0.1.43",
-                          "from": "source-map@>=0.1.7 <0.2.0",
+                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "1.0.0",
-                              "from": "amdefine@>=0.0.4",
+                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                             }
                           }
                         },
                         "optimist": {
                           "version": "0.3.7",
-                          "from": "optimist@>=0.3.5 <0.4.0",
+                          "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                           "dependencies": {
                             "wordwrap": {
                               "version": "0.0.3",
-                              "from": "wordwrap@>=0.0.2 <0.1.0",
+                              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                             }
                           }
@@ -1217,59 +1217,66 @@
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.3.4 <2.4.0",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 },
                 "uglify-js": {
                   "version": "2.4.24",
-                  "from": "uglify-js@>=2.4.0 <2.5.0",
+                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@>=0.2.6 <0.3.0",
+                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "source-map": {
                       "version": "0.1.34",
-                      "from": "source-map@0.1.34",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "1.0.0",
-                          "from": "amdefine@>=0.0.4",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                         }
                       }
                     },
                     "uglify-to-browserify": {
                       "version": "1.0.2",
-                      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                     },
                     "yargs": {
                       "version": "3.5.4",
-                      "from": "yargs@>=3.5.4 <3.6.0",
+                      "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
                       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
-                          "from": "camelcase@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "decamelize": {
-                          "version": "1.1.1",
-                          "from": "decamelize@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+                          "version": "1.1.2",
+                          "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
+                          "dependencies": {
+                            "escape-string-regexp": {
+                              "version": "1.0.4",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                            }
+                          }
                         },
                         "window-size": {
                           "version": "0.1.0",
-                          "from": "window-size@0.1.0",
+                          "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                         },
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "wordwrap@0.0.2",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         }
                       }
@@ -1280,185 +1287,185 @@
             },
             "url": {
               "version": "0.10.3",
-              "from": "url@>=0.10.1 <0.11.0",
+              "from": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
               "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
               "dependencies": {
                 "punycode": {
                   "version": "1.3.2",
-                  "from": "punycode@1.3.2",
+                  "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                 },
                 "querystring": {
                   "version": "0.2.0",
-                  "from": "querystring@0.2.0",
+                  "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
                 }
               }
             },
             "util": {
               "version": "0.10.3",
-              "from": "util@>=0.10.1 <0.11.0",
+              "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
               "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
             },
             "vm-browserify": {
               "version": "0.0.4",
-              "from": "vm-browserify@>=0.0.1 <0.1.0",
+              "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
               "dependencies": {
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "indexof@0.0.1",
+                  "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "3.0.0",
-              "from": "xtend@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
             },
             "process": {
               "version": "0.7.0",
-              "from": "process@>=0.7.0 <0.8.0",
+              "from": "https://registry.npmjs.org/process/-/process-0.7.0.tgz",
               "resolved": "https://registry.npmjs.org/process/-/process-0.7.0.tgz"
             }
           }
         },
         "govuk_frontend_toolkit": {
-          "version": "3.5.1",
-          "from": "govuk_frontend_toolkit@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/govuk_frontend_toolkit/-/govuk_frontend_toolkit-3.5.1.tgz"
+          "version": "4.6.1",
+          "from": "https://registry.npmjs.org/govuk_frontend_toolkit/-/govuk_frontend_toolkit-4.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/govuk_frontend_toolkit/-/govuk_frontend_toolkit-4.6.1.tgz"
         },
         "mustache": {
           "version": "1.2.0",
-          "from": "mustache@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/mustache/-/mustache-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/mustache/-/mustache-1.2.0.tgz"
         },
         "underscore": {
           "version": "1.8.3",
-          "from": "underscore@>=1.8.3 <2.0.0",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
         }
       }
     },
     "hmpo-govuk-template": {
       "version": "0.0.3",
-      "from": "hmpo-govuk-template@0.0.3",
+      "from": "https://registry.npmjs.org/hmpo-govuk-template/-/hmpo-govuk-template-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/hmpo-govuk-template/-/hmpo-govuk-template-0.0.3.tgz",
       "dependencies": {
         "govuk_template_mustache": {
           "version": "0.12.0",
-          "from": "govuk_template_mustache@0.12.0",
+          "from": "https://registry.npmjs.org/govuk_template_mustache/-/govuk_template_mustache-0.12.0.tgz",
           "resolved": "https://registry.npmjs.org/govuk_template_mustache/-/govuk_template_mustache-0.12.0.tgz"
         },
         "hogan.js": {
           "version": "3.0.2",
-          "from": "hogan.js@3.0.2",
+          "from": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
           "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
           "dependencies": {
             "nopt": {
               "version": "1.0.10",
-              "from": "nopt@1.0.10",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "mkdirp": {
               "version": "0.3.0",
-              "from": "mkdirp@0.3.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
             }
           }
         },
         "serve-static": {
           "version": "1.8.1",
-          "from": "serve-static@1.8.1",
+          "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.8.1.tgz",
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.8.1.tgz",
           "dependencies": {
             "escape-html": {
               "version": "1.0.1",
-              "from": "escape-html@1.0.1",
+              "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
             },
             "parseurl": {
-              "version": "1.3.0",
-              "from": "parseurl@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+              "version": "1.3.1",
+              "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
             },
             "send": {
               "version": "0.11.1",
-              "from": "send@0.11.1",
+              "from": "https://registry.npmjs.org/send/-/send-0.11.1.tgz",
               "resolved": "https://registry.npmjs.org/send/-/send-0.11.1.tgz",
               "dependencies": {
                 "debug": {
                   "version": "2.1.3",
-                  "from": "debug@>=2.1.1 <2.2.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz"
                 },
                 "depd": {
                   "version": "1.0.1",
-                  "from": "depd@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
                 },
                 "destroy": {
                   "version": "1.0.3",
-                  "from": "destroy@1.0.3",
+                  "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
                 },
                 "etag": {
                   "version": "1.5.1",
-                  "from": "etag@>=1.5.1 <1.6.0",
+                  "from": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
                   "dependencies": {
                     "crc": {
                       "version": "3.2.1",
-                      "from": "crc@3.2.1",
+                      "from": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
                     }
                   }
                 },
                 "fresh": {
                   "version": "0.2.4",
-                  "from": "fresh@0.2.4",
+                  "from": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz",
                   "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@1.2.11",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "ms": {
                   "version": "0.7.0",
-                  "from": "ms@0.7.0",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
                 },
                 "on-finished": {
                   "version": "2.2.1",
-                  "from": "on-finished@>=2.2.0 <2.3.0",
+                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.1.0",
-                      "from": "ee-first@1.1.0",
+                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
                     }
                   }
                 },
                 "range-parser": {
                   "version": "1.0.3",
-                  "from": "range-parser@>=1.0.2 <1.1.0",
+                  "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
                 }
               }
             },
             "utils-merge": {
               "version": "1.0.0",
-              "from": "utils-merge@1.0.0",
+              "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
             }
           }
@@ -1466,53 +1473,53 @@
       }
     },
     "hmpo-model": {
-      "version": "0.1.2",
-      "from": "hmpo-model@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/hmpo-model/-/hmpo-model-0.1.2.tgz",
+      "version": "0.2.0",
+      "from": "https://registry.npmjs.org/hmpo-model/-/hmpo-model-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/hmpo-model/-/hmpo-model-0.2.0.tgz",
       "dependencies": {
         "concat-stream": {
           "version": "1.5.1",
-          "from": "concat-stream@>=1.4.7 <2.0.0",
+          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@>=0.0.5 <0.1.0",
+              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
-              "version": "2.0.4",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+              "version": "2.0.5",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -1521,92 +1528,92 @@
         },
         "underscore": {
           "version": "1.8.3",
-          "from": "underscore@>=1.7.0 <2.0.0",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
         }
       }
     },
     "hmpo-template-mixins": {
-      "version": "3.3.0",
-      "from": "hmpo-template-mixins@>=3.3.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/hmpo-template-mixins/-/hmpo-template-mixins-3.3.0.tgz",
+      "version": "3.5.0",
+      "from": "https://registry.npmjs.org/hmpo-template-mixins/-/hmpo-template-mixins-3.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/hmpo-template-mixins/-/hmpo-template-mixins-3.5.0.tgz",
       "dependencies": {
         "hogan.js": {
           "version": "3.0.2",
-          "from": "hogan.js@3.0.2",
+          "from": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
           "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
           "dependencies": {
             "nopt": {
               "version": "1.0.10",
-              "from": "nopt@1.0.10",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "mkdirp": {
               "version": "0.3.0",
-              "from": "mkdirp@0.3.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
             }
           }
         },
         "moment": {
-          "version": "2.10.6",
-          "from": "moment@>=2.9.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
+          "version": "2.11.1",
+          "from": "https://registry.npmjs.org/moment/-/moment-2.11.1.tgz",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.1.tgz"
         },
         "underscore": {
           "version": "1.8.3",
-          "from": "underscore@>=1.7.0 <2.0.0",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
         }
       }
     },
     "hof-controllers": {
       "version": "0.1.1",
-      "from": "hof-controllers@0.1.1",
+      "from": "https://registry.npmjs.org/hof-controllers/-/hof-controllers-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/hof-controllers/-/hof-controllers-0.1.1.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.10.1 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "moment": {
-          "version": "2.10.6",
-          "from": "moment@>=2.9.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
+          "version": "2.11.1",
+          "from": "https://registry.npmjs.org/moment/-/moment-2.11.1.tgz",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.1.tgz"
         },
         "moment-business": {
           "version": "2.0.0",
-          "from": "moment-business@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/moment-business/-/moment-business-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/moment-business/-/moment-business-2.0.0.tgz",
           "dependencies": {
             "contained-periodic-values": {
               "version": "1.0.0",
-              "from": "contained-periodic-values@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/contained-periodic-values/-/contained-periodic-values-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/contained-periodic-values/-/contained-periodic-values-1.0.0.tgz",
               "dependencies": {
                 "nearest-periodic-value": {
                   "version": "1.2.0",
-                  "from": "nearest-periodic-value@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/nearest-periodic-value/-/nearest-periodic-value-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/nearest-periodic-value/-/nearest-periodic-value-1.2.0.tgz"
                 }
               }
             },
             "skipped-periodic-values": {
               "version": "1.0.1",
-              "from": "skipped-periodic-values@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/skipped-periodic-values/-/skipped-periodic-values-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/skipped-periodic-values/-/skipped-periodic-values-1.0.1.tgz",
               "dependencies": {
                 "nearest-periodic-value": {
                   "version": "1.2.0",
-                  "from": "nearest-periodic-value@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/nearest-periodic-value/-/nearest-periodic-value-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/nearest-periodic-value/-/nearest-periodic-value-1.2.0.tgz"
                 }
               }
@@ -1616,55 +1623,55 @@
       }
     },
     "i18n-future": {
-      "version": "0.1.4",
-      "from": "i18n-future@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/i18n-future/-/i18n-future-0.1.4.tgz",
+      "version": "0.2.0",
+      "from": "https://registry.npmjs.org/i18n-future/-/i18n-future-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/i18n-future/-/i18n-future-0.2.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.7.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "glob": {
           "version": "5.0.15",
-          "from": "glob@>=5.0.5 <6.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "3.0.0",
-              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.2",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -1673,34 +1680,22 @@
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             }
           }
-        }
-      }
-    },
-    "i18n-lookup": {
-      "version": "0.1.0",
-      "from": "i18n-lookup@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/i18n-lookup/-/i18n-lookup-0.1.0.tgz",
-      "dependencies": {
-        "underscore": {
-          "version": "1.8.3",
-          "from": "underscore@>=1.7.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Home Office Forms (HOF) single package that bundles up a collection of packages used to create forms at the Home Office in node.js.",
   "main": "index.js",
   "repository": {
@@ -19,14 +19,13 @@
   },
   "homepage": "https://github.com/UKHomeOffice/hof",
   "dependencies": {
-    "hmpo-form-wizard": "^3.2.0",
-    "hmpo-frontend-toolkit": "^1.5.0",
+    "hmpo-form-wizard": "^3.3.0",
+    "hmpo-frontend-toolkit": "^2.0.0",
     "hmpo-govuk-template": "0.0.3",
-    "hmpo-model": "^0.1.2",
-    "hmpo-template-mixins": "^3.3.0",
+    "hmpo-model": "^0.2.0",
+    "hmpo-template-mixins": "^3.5.0",
     "hof-controllers": "0.1.1",
-    "i18n-future": "^0.1.4",
-    "i18n-lookup": "^0.1.0"
+    "i18n-future": "^0.2.0"
   },
   "browser": {
     "hmpo-form-wizard": false,


### PR DESCRIPTION
This doesn't need to be part of the core library.

Version bump modules to latest versions.
