### PR TITLE
New hof middleware (currently only deals with cookie checking)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,437 @@
+env:
+  node: true
+
+plugins:
+  - filenames
+  - one-variable-per-var
+  - mocha
+
+rules:
+
+  # ## Possible Errors
+  # The following rules point out areas where you might have made mistakes.
+
+  # disallow trailing commas in object literals
+  comma-dangle: 0
+  # disallow assignment in conditional expressions
+  no-cond-assign: 2
+  # disallow use of console
+  no-console: 2
+  # disallow use of constant expressions in conditions
+  no-constant-condition: 2
+  # disallow control characters in regular expressions
+  no-control-regex: 2
+  # disallow use of debugger
+  no-debugger: 2
+  # disallow duplicate keys when creating object literals
+  no-dupe-keys: 2
+  # disallow empty statements
+  no-empty: 2
+  # disallow the use of empty character classes in regular expressions
+  no-empty-class: 2
+  # disallow assigning to the exception in a catch block
+  no-ex-assign: 2
+  # disallow double-negation boolean casts in a boolean context
+  no-extra-boolean-cast: 2
+  # disallow unnecessary parentheses
+  no-extra-parens: 0
+  # disallow unnecessary semicolons
+  no-extra-semi: 2
+  # disallow overwriting functions written as function declarations
+  no-func-assign: 2
+  # disallow function or variable declarations in nested blocks
+  no-inner-declarations: 2
+  # disallow invalid regular expression strings in the RegExp constructor
+  no-invalid-regexp: 2
+  # disallow irregular whitespace outside of strings and comments
+  no-irregular-whitespace: 2
+  # disallow negation of the left operand of an in expression
+  no-negated-in-lhs: 2
+  # disallow the use of object properties of the global object (Math and JSON)
+  # as functions
+  no-obj-calls: 2
+  # disallow multiple spaces in a regular expression literal
+  no-regex-spaces: 2
+  # disallow reserved words being used as object literal keys
+  no-reserved-keys: 0
+  # disallow sparse arrays
+  no-sparse-arrays: 2
+  # disallow unreachable statements after a return, throw, continue, or break
+  # statement
+  no-unreachable: 2
+  # disallow comparisons with the value NaN
+  use-isnan: 2
+  # Ensure JSDoc comments are valid
+  valid-jsdoc: 0
+  # Ensure that the results of typeof are compared against a valid string
+  valid-typeof: 2
+
+  # ## Best Practices
+  # These are rules designed to prevent you from making mistakes. They either
+  # prescribe a better way of doing something or help you avoid footguns.
+
+  # treat var statements as if they were block scoped
+  block-scoped-var: 0
+  # specify the maximum cyclomatic complexity allowed in a program
+  complexity:
+    - 2
+    # Maximum cycolmatic complexity
+    - 10
+  # require return statements to either always or never specify values
+  consistent-return: 2
+  # specify curly brace conventions for all control statements
+  curly: 2
+  # require default case in switch statements
+  default-case: 2
+  # encourages use of dot notation whenever possible
+  dot-notation: 2
+  # require the use of === and !==
+  eqeqeq: 2
+  # make sure for-in loops have an if statement
+  guard-for-in: 0
+  # disallow the use of alert, confirm, and prompt
+  no-alert: 2
+  # disallow use of arguments.caller or arguments.callee
+  no-caller: 2
+  # disallow division operators explicitly at beginning of regular expression
+  no-div-regex: 2
+  # disallow else after a return in an if
+  no-else-return: 2
+  # disallow use of labels for anything other then loops and switches
+  no-empty-label: 2
+  # disallow comparisons to null without a type-checking operator
+  no-eq-null: 2
+  # disallow use of eval()
+  no-eval: 2
+  # disallow adding to native types
+  no-extend-native: 2
+  # disallow unnecessary function binding
+  no-extra-bind: 2
+  # disallow fallthrough of case statements
+  no-fallthrough: 2
+  # disallow the use of leading or trailing decimal points in numeric literals
+  no-floating-decimal: 2
+  # disallow use of eval()-like methods
+  no-implied-eval: 2
+  # disallow usage of __iterator__ property
+  no-iterator: 2
+  # disallow use of labeled statements
+  no-labels: 0
+  # disallow unnecessary nested blocks
+  no-lone-blocks: 2
+  # disallow creation of functions within loops
+  no-loop-func: 2
+  # disallow use of multiple spaces
+  no-multi-spaces: 2
+  # disallow use of multiline strings
+  no-multi-str: 2
+  # disallow reassignments of native objects
+  no-native-reassign: 2
+  # disallow use of new operator when not part of the assignment or comparison
+  no-new: 2
+  # disallow use of new operator for Function object
+  no-new-func: 2
+  # disallows creating new instances of String,Number, and Boolean
+  no-new-wrappers: 2
+  # disallow use of (old style) octal literals
+  no-octal: 2
+  # disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
+  no-octal-escape: 2
+  # disallow use of process.env
+  no-process-env: 2
+  # disallow usage of __proto__ property
+  no-proto: 2
+  # disallow declaring the same variable more then once
+  no-redeclare: 2
+  # disallow use of assignment in return statement
+  no-return-assign: 2
+  # disallow use of javascript: [] urls.
+  no-script-url: 2
+  # disallow comparisons where both sides are exactly the same
+  no-self-compare: 2
+  # disallow use of comma operator
+  no-sequences: 2
+  # disallow usage of expressions in statement position
+  no-unused-expressions: 2
+  # disallow use of void operator
+  no-void: 2
+  # disallow usage of configurable warning terms in comments: [] e.g. todo
+  no-warning-comments:
+    - 2
+    # Disallowed warning terms
+    - terms:
+        - todo
+        - fixme
+        - xxx
+    # Comment location to check
+      location: anywhere
+  # disallow use of the with statement
+  no-with: 2
+  # require use of the second argument for parseInt()
+  radix: 2
+  # requires to declare all vars on top of their containing scope
+  vars-on-top: 0
+  # require immediate function invocation to be wrapped in parentheses
+  wrap-iife: 2
+  # require or disallow Yoda conditions
+  yoda: 2
+
+
+  # ## Strict Mode
+  # These rules relate to using strict mode.
+
+  # require or disallow the "use strict" pragma in the global scope
+  global-strict:
+    - 2
+    # Enforce global strict by default
+    - "always"
+  # disallow unnecessary use of "use strict"; when already in strict mode
+  no-extra-strict: 2
+  # require that all functions are run in strict mode
+  strict: 2
+
+
+  # ## Variables
+  # These rules have to do with variable declarations.
+
+  # disallow the catch clause parameter name being the same as a variable in the
+  # outer scope
+  no-catch-shadow: 0
+  # disallow deletion of variables
+  no-delete-var: 2
+  # disallow labels that share a name with a variable
+  no-label-var: 2
+  # disallow declaration of variables already declared in the outer scope
+  no-shadow: 2
+  # disallow shadowing of names such as arguments
+  no-shadow-restricted-names: 2
+  # disallow use of undeclared variables unless mentioned in a /*global */ block
+  no-undef: 2
+  # disallow use of undefined when initializing variables
+  no-undef-init: 2
+  # disallow use of undefined variable
+  no-undefined: 0
+  # disallow declaration of variables that are not used in the code
+  no-unused-vars: 2
+  # disallow use of variables before they are defined
+  no-use-before-define: 2
+
+  # ## Node.js
+  # These rules are specific to JavaScript running on Node.js.
+
+  # enforces error handling in callbacks
+  # node environment)
+  handle-callback-err:
+    - 2
+    # name of error argument
+    - ^.*(e|E)rr(or)?$
+  # disallow mixing regular variable and require declarations
+  no-mixed-requires: 2
+  # disallow use of new operator with the require function
+  no-new-require: 2
+  # disallow string concatenation with __dirname and __filename
+  no-path-concat: 2
+  # disallow process.exit()
+  no-process-exit: 2
+  # restrict usage of specified node modules
+  no-restricted-modules: 0
+
+
+  # ## Stylistic Issues
+  # These rules are purely matters of style and are quite subjective.
+
+  # enforce one true brace style
+  brace-style:
+    - 2
+    # brace-style (1tbs or stroustrup)
+    - 1tbs
+    # allow the start and end braces to be on the same line
+    - allowSingleLine: false
+  # require camel case names
+  camelcase: 2
+  # enforce spacing before and after comma
+  comma-spacing:
+    - 2
+    # enforce spaces before
+    - before: false
+    # enforce spaces after
+      after: true
+  # enforce one true comma style
+  comma-style:
+    - 2
+    # enforce comma on the first line, or the last line
+    - last
+  # enforces consistent naming when capturing the current execution context
+  consistent-this:
+    - 2
+    # Variable name that a `this` alias must be
+    - this # ensure devs cannot alias this
+  # enforce newline at the end of file, with no multiple empty lines
+  eol-last: 2
+  # require function expressions to have a name
+  func-names: 2
+  # enforces use of function declarations or expressions
+  func-style: 0
+  # enforces spacing between keys and values in object literal properties
+  key-spacing:
+    - 2
+    # enforce spaces before colon
+    - beforeColon: false
+    # enforce spaces after colon
+      afterColon: true
+  # specify the maximum depth callbacks can be nested
+  max-nested-callbacks:
+    - 2
+    # max amount of nested callbacks
+    - 3
+  # require a capital letter for constructors
+  new-cap:
+    - 2
+    # require constructors called with new to be capped
+    - newIsCap: true
+    # require functions with capital to always be called with new
+      capIsNew: false
+  # disallow the omission of parentheses when invoking a constructor with no arguments
+  new-parens: 2
+  # disallow use of the Array constructor
+  no-array-constructor: 2
+  # disallow comments inline after code
+  no-inline-comments: 2
+  # disallow if as the only statement in an else block
+  no-lonely-if: 2
+  # disallow mixed spaces and tabs for indentation
+  no-mixed-spaces-and-tabs: 2
+  # disallow multiple empty lines
+  no-multiple-empty-lines: 2
+  # disallow nested ternary expressions
+  no-nested-ternary: 2
+  # disallow use of the Object constructor
+  no-new-object: 2
+  # disallow space before semicolon
+  no-space-before-semi: 2
+  # disallow space between function identifier and application
+  no-spaced-func: 2
+  # disallow the use of ternary operators
+  no-ternary: 0
+  # disallow trailing whitespace at the end of lines
+  no-trailing-spaces: 2
+  # disallow dangling underscores in identifiers
+  no-underscore-dangle: 2
+  # disallow wrapping of non-IIFE statements in parens
+  no-wrap-func: 2
+  # allow just one var statement per function
+  one-var: 0
+  # require assignment operator shorthand where possible or prohibit it entirely
+  operator-assignment:
+    - 2
+    # enforce them to be "always" used when possible, or "never" used
+    - always
+  # enforce padding within blocks
+  padded-blocks:
+    - 0
+    # enforce them to be "always" used when possible, or "never" used
+    - never
+  # require quotes around object literal property names
+  quote-props: 0
+  # specify whether double or single quotes should be used
+  quotes:
+    - 2
+    # "double" or 'single' quotes should always be enforced
+    - single
+  # require or disallow use of semicolons instead of ASI
+  semi:
+    - 2
+    # enforce them to be "always" used when possible, or "never" used
+    - always
+  # sort variables within the same declaration block
+  sort-vars: 0
+  # require a space after function names
+  space-after-function-name:
+    - 2
+    # enforce them to be "always" used when possible, or "never" used
+    - never
+  # require a space after certain keywords
+  space-after-keywords:
+    - 2
+    # enforce them to be "always" used when possible, or "never" used
+    - always
+  # require or disallow space before blocks
+  space-before-blocks:
+    - 2
+    # enforce them to be "always" used when possible, or "never" used
+    - always
+  # require or disallow spaces inside brackets
+  space-in-brackets:
+    - 2
+    # enforce them to be "always" used when possible, or "never" used
+    - never
+  # require or disallow spaces inside parentheses
+  space-in-parens:
+    - 2
+    # enforce them to be "always" used when possible, or "never" used
+    - never
+  # require spaces around operators
+  space-infix-ops: 2
+  # require a space after return, throw, and case
+  space-return-throw-case: 2
+  # Require or disallow spaces before/after unary operators
+  space-unary-ops: 2
+  # require or disallow a space immediately following the // in a line comment
+  spaced-line-comment:
+    - 2
+    # enforce them to be "always" used when possible, or "never" used
+    - always
+  # require regex literals to be wrapped in parentheses
+  wrap-regex: 0
+
+  # ## ECMAScript 6
+  # These rules are only relevant to ES6 environments and are off by default.
+
+  # require let or const instead of var
+  no-var: 0
+  # enforce the position of the * in generator functions
+  generator-star: 2
+
+  # ## Legacy
+  # The following rules are included for compatibility with JSHint and JSLint.
+  # While the names of the rules may not match up with the JSHint/JSLint
+  # counterpart, the functionality is the same.
+
+  # specify the maximum depth that blocks can be nested
+  max-depth:
+    - 2
+    # the max depth
+    - 5
+  # specify the maximum length of a line in your program
+  max-len:
+    - 2
+    # line length
+    - 120
+  # limits the number of parameters that can be used in the function declaration.
+  max-params:
+    - 2
+    # max params
+    - 5
+  # specify the maximum number of statement allowed in a function
+  max-statements:
+    - 2
+    # max statements
+    - 50
+  # disallow use of bitwise operators
+  no-bitwise: 2
+  # disallow use of unary operators, ++ and --
+  no-plusplus: 0
+
+
+  # ## Plugins
+  # The following rules are included based on the plugins available.
+
+  # specify a pattern file names must match
+  filenames/filenames:
+    - 2
+    # the pattern a file name must match
+    # ('<text>' is to ensure interop with eslint --stdin)
+    - '^(<text>$|[a-z\-\.]+$)'
+
+  # enforce declaring only one variable per var statement
+  one-variable-per-var/one-variable-per-var: 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.jscsrc.json
+++ b/.jscsrc.json
@@ -1,0 +1,5 @@
+{
+  "preset": "google",
+  "maximumLineLength": 120,
+  "excludeFiles": ["node_modules/**", "reports/**", "dist/js/bundle.js"]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+node_js:
+  - "0.12"
+  - "4"
+  - "5"
+
+cache:
+  directories:
+    - node_modules
+
+script:
+  - npm run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # HOF ChangeLog
 
+## 2016-03-03, Version 3.2.0 (Stable), @easternbloc
+
+### Notable changes
+
+* **HOF-Middleware**: Added support for cookie checking on all routes other than /cookies-required
+
 ## 2015-11-25, Version 1.1.0 (Stable), @Joechapman
 
 ### Notable changes

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ HOF comprises the following modules.
  * [hmpo-template-mixins](https://github.com/UKHomeOffice/passports-template-mixins)
  * [hof-controllers](https://github.com/UKHomeOffice/hof-controllers)
  * [i18n-future](https://github.com/lennym/i18n-future)
+ * [middleware](https://github.com/UKHomeOffice/hof/documentation/middleware.md)
 
 And each module is available as a property of `hof`
 
@@ -36,4 +37,5 @@ var Model = hof.Model;
 var mixins = hof.mixins;
 var controllers = hof.controllers;
 var i18n = hof.i18n;
+var middleware = hof.middleware;
 ```

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -8,3 +8,4 @@ Successfully developing a form-based application using HOF requires the implemen
 * [translations](./translations.md)
 * [structure](./structure.md)
 * [wizard](./wizard.md)
+* [middleware](./middleware.md)

--- a/documentation/middleware.md
+++ b/documentation/middleware.md
@@ -1,0 +1,17 @@
+# Middleware
+
+HOF exports a middleware as `middleware`, a small collection of routes and middlewares. Currently the middleware only adds support for enforcing that a cookie is set and if not redirecting to a /cookies-required page.
+
+## Usage
+
+```js
+app.use(require('hof').middleware({
+  'cookie-name': 'my-application-cookie'
+}));
+```
+
+This middleware must be declared before your other routes.
+
+When this middleware is used it will add one new route that you will need to create a template for:
+
+ * /cookies-required

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var hof = {
   wizard: require('hmpo-form-wizard'),
   toolkit: require('hmpo-frontend-toolkit'),
@@ -5,7 +7,8 @@ var hof = {
   Model: require('hmpo-model'),
   mixins: require('hmpo-template-mixins'),
   controllers: require('hof-controllers'),
-  i18n: require('i18n-future')
+  i18n: require('i18n-future'),
+  middleware: require('./lib/middleware')
 };
 
 module.exports = hof;

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -6,17 +6,17 @@ module.exports = function generateMiddleware(options) {
 
   options = options || {};
 
-  options['cookie-name'] = options['cookie-name'] || 'hof-cookie-check';
+  var cookieName = options['cookie-name'] || 'hof-cookie-check';
 
-  middleware.get('/cookies-required', function renderCookiesRequired(req, res) {
-    res.render('cookies-required');
-  });
+  middleware.get('/cookies-required', function checkCookie(req, res) {
+    var location = req.query.location;
 
-  middleware.get('/check-cookies', function checkCookie(req, res) {
-    if (Object.keys(req.cookies).length && req.cookies[options['cookie-name']]) {
-      res.redirect(req.cookies[options['cookie-name']]);
+    if (Object.keys(req.cookies).length &&
+        req.cookies[cookieName] &&
+        req.cookies[cookieName] === location) {
+      res.redirect(location);
     } else {
-      res.redirect('/cookies-required');
+      res.render('cookies-required');
     }
   });
 
@@ -25,7 +25,7 @@ module.exports = function generateMiddleware(options) {
       next();
     } else {
       res.cookie(options['cookie-name'], req.originalUrl);
-      res.redirect('/check-cookies');
+      res.redirect('/cookies-required?location=' + encodeURIComponent(req.originalUrl));
     }
   });
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var middleware = require('express').Router();
+
+module.exports = function generateMiddleware(options) {
+
+  options = options || {};
+
+  options['cookie-name'] = options['cookie-name'] || 'hof-cookie-check';
+
+  middleware.get('/cookies-required', function renderCookiesRequired(req, res) {
+    res.render('cookies-required');
+  });
+
+  middleware.get('/check-cookies', function checkCookie(req, res) {
+    if (Object.keys(req.cookies).length && req.cookies[options['cookie-name']]) {
+      res.redirect(req.cookies[options['cookie-name']]);
+    } else {
+      res.redirect('/cookies-required');
+    }
+  });
+
+  middleware.use(function ensureCookie(req, res, next) {
+    if (Object.keys(req.cookies).length && req.cookies[options['cookie-name']]) {
+      next();
+    } else {
+      res.cookie(options['cookie-name'], req.originalUrl);
+      res.redirect('/check-cookies');
+    }
+  });
+
+  return middleware;
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,7 +1,388 @@
 {
   "name": "hof",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "dependencies": {
+    "accepts": {
+      "version": "1.2.13",
+      "from": "accepts@>=1.2.12 <1.3.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz"
+    },
+    "ansi-regex": {
+      "version": "2.0.0",
+      "from": "ansi-regex@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+    },
+    "ansi-styles": {
+      "version": "2.2.0",
+      "from": "ansi-styles@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz"
+    },
+    "argparse": {
+      "version": "1.0.6",
+      "from": "argparse@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.6.tgz"
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "from": "array-flatten@1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
+    },
+    "assertion-error": {
+      "version": "1.0.1",
+      "from": "assertion-error@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.1.tgz"
+    },
+    "async": {
+      "version": "0.2.10",
+      "from": "async@>=0.2.9 <0.3.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+    },
+    "balanced-match": {
+      "version": "0.3.0",
+      "from": "balanced-match@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+    },
+    "brace-expansion": {
+      "version": "1.1.3",
+      "from": "brace-expansion@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz"
+    },
+    "chalk": {
+      "version": "1.1.1",
+      "from": "chalk@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+    },
+    "cli-table": {
+      "version": "0.3.1",
+      "from": "cli-table@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz"
+    },
+    "cli-width": {
+      "version": "1.1.1",
+      "from": "cli-width@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz"
+    },
+    "color-convert": {
+      "version": "1.0.0",
+      "from": "color-convert@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+    },
+    "colors": {
+      "version": "1.0.3",
+      "from": "colors@1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+    },
+    "commander": {
+      "version": "2.6.0",
+      "from": "commander@>=2.6.0 <2.7.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "from": "concat-map@0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+    },
+    "concat-stream": {
+      "version": "1.5.1",
+      "from": "concat-stream@>=1.4.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz"
+    },
+    "content-disposition": {
+      "version": "0.5.1",
+      "from": "content-disposition@0.5.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
+    },
+    "content-type": {
+      "version": "1.0.1",
+      "from": "content-type@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+    },
+    "cookie": {
+      "version": "0.1.5",
+      "from": "cookie@0.1.5",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz"
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "from": "cookie-signature@1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "from": "core-util-is@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+    },
+    "cross-spawn": {
+      "version": "2.0.1",
+      "from": "cross-spawn@>=2.0.0 <2.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.0.1.tgz"
+    },
+    "cross-spawn-async": {
+      "version": "2.1.9",
+      "from": "cross-spawn-async@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.1.9.tgz",
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.0.0",
+          "from": "lru-cache@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz"
+        },
+        "which": {
+          "version": "1.2.4",
+          "from": "which@>=1.2.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz"
+        }
+      }
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "from": "cycle@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
+    },
+    "d": {
+      "version": "0.1.1",
+      "from": "d@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+    },
+    "debug": {
+      "version": "2.2.0",
+      "from": "debug@>=2.2.0 <2.3.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "from": "deep-eql@>=0.1.3 <0.2.0",
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "from": "type-detect@0.1.1"
+        }
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "from": "deep-equal@*",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "from": "deep-is@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+    },
+    "depd": {
+      "version": "1.1.0",
+      "from": "depd@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "from": "destroy@>=1.0.4 <1.1.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+    },
+    "diff": {
+      "version": "1.4.0",
+      "from": "diff@1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
+    },
+    "doctrine": {
+      "version": "0.6.4",
+      "from": "doctrine@>=0.6.2 <0.7.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz"
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "from": "ee-first@1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+    },
+    "es5-ext": {
+      "version": "0.10.11",
+      "from": "es5-ext@>=0.10.8 <0.11.0",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
+    },
+    "es6-iterator": {
+      "version": "2.0.0",
+      "from": "es6-iterator@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+    },
+    "es6-map": {
+      "version": "0.1.3",
+      "from": "es6-map@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz"
+    },
+    "es6-set": {
+      "version": "0.1.4",
+      "from": "es6-set@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz"
+    },
+    "es6-symbol": {
+      "version": "3.0.2",
+      "from": "es6-symbol@>=3.0.1 <3.1.0",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
+    },
+    "es6-weak-map": {
+      "version": "2.0.1",
+      "from": "es6-weak-map@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz"
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "from": "escape-html@>=1.0.3 <1.1.0",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+    },
+    "escope": {
+      "version": "3.5.0",
+      "from": "escope@>=3.1.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.5.0.tgz",
+      "dependencies": {
+        "estraverse": {
+          "version": "4.1.1",
+          "from": "estraverse@>=4.1.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
+        }
+      }
+    },
+    "espree": {
+      "version": "2.2.5",
+      "from": "espree@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
+    },
+    "esprima-harmony-jscs": {
+      "version": "1.1.0-bin",
+      "from": "esprima-harmony-jscs@1.1.0-bin",
+      "resolved": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-bin.tgz"
+    },
+    "esrecurse": {
+      "version": "4.0.0",
+      "from": "esrecurse@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.0.0.tgz",
+      "dependencies": {
+        "estraverse": {
+          "version": "4.1.1",
+          "from": "estraverse@>=4.1.0 <4.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
+        },
+        "object-assign": {
+          "version": "4.0.1",
+          "from": "object-assign@>=4.0.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+        }
+      }
+    },
+    "estraverse": {
+      "version": "2.0.0",
+      "from": "estraverse@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz"
+    },
+    "estraverse-fb": {
+      "version": "1.3.1",
+      "from": "estraverse-fb@>=1.3.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
+    },
+    "esutils": {
+      "version": "1.1.6",
+      "from": "esutils@>=1.1.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+    },
+    "etag": {
+      "version": "1.7.0",
+      "from": "etag@>=1.7.0 <1.8.0",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+    },
+    "event-emitter": {
+      "version": "0.3.4",
+      "from": "event-emitter@>=0.3.4 <0.4.0",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
+    },
+    "exit": {
+      "version": "0.1.2",
+      "from": "exit@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+    },
+    "express": {
+      "version": "4.13.4",
+      "from": "express@*",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.13.4.tgz"
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "from": "eyes@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
+    },
+    "fast-levenshtein": {
+      "version": "1.0.7",
+      "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+    },
+    "figures": {
+      "version": "1.4.0",
+      "from": "figures@>=1.3.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
+    },
+    "finalhandler": {
+      "version": "0.4.1",
+      "from": "finalhandler@0.4.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz"
+    },
+    "formatio": {
+      "version": "1.1.1",
+      "from": "formatio@1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
+    },
+    "forwarded": {
+      "version": "0.1.0",
+      "from": "forwarded@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+    },
+    "fresh": {
+      "version": "0.3.0",
+      "from": "fresh@0.3.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "from": "generate-function@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "from": "generate-object-property@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "from": "get-stdin@>=4.0.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+    },
+    "glob": {
+      "version": "5.0.15",
+      "from": "glob@>=5.0.1 <6.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+    },
+    "globals": {
+      "version": "8.18.0",
+      "from": "globals@>=8.0.0 <9.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
+    },
+    "graceful-fs": {
+      "version": "2.0.3",
+      "from": "graceful-fs@>=2.0.0 <2.1.0",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+    },
+    "growl": {
+      "version": "1.8.1",
+      "from": "growl@1.8.1",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "from": "has-ansi@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+    },
     "hmpo-form-wizard": {
       "version": "4.0.0",
       "from": "hmpo-form-wizard@>=4.0.0 <5.0.0",
@@ -305,11 +686,6 @@
                   "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
-                "typedarray": {
-                  "version": "0.0.6",
-                  "from": "typedarray@>=0.0.5 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-                },
                 "readable-stream": {
                   "version": "2.0.5",
                   "from": "readable-stream@>=2.0.0 <2.1.0",
@@ -341,6 +717,11 @@
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
+                },
+                "typedarray": {
+                  "version": "0.0.6",
+                  "from": "typedarray@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 }
               }
             }
@@ -351,6 +732,11 @@
           "from": "hogan.js@>=3.0.2 <4.0.0",
           "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
           "dependencies": {
+            "mkdirp": {
+              "version": "0.3.0",
+              "from": "mkdirp@0.3.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+            },
             "nopt": {
               "version": "1.0.10",
               "from": "nopt@1.0.10",
@@ -362,11 +748,6 @@
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
-            },
-            "mkdirp": {
-              "version": "0.3.0",
-              "from": "mkdirp@0.3.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
             }
           }
         },
@@ -397,23 +778,6 @@
           "from": "browserify@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/browserify/-/browserify-4.2.3.tgz",
           "dependencies": {
-            "JSONStream": {
-              "version": "0.8.4",
-              "from": "JSONStream@>=0.8.3 <0.9.0",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
-              "dependencies": {
-                "jsonparse": {
-                  "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
-                },
-                "through": {
-                  "version": "2.3.8",
-                  "from": "through@>=2.2.7 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                }
-              }
-            },
             "assert": {
               "version": "1.1.2",
               "from": "assert@>=1.1.0 <1.2.0",
@@ -424,6 +788,49 @@
               "from": "browser-pack@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-2.0.1.tgz",
               "dependencies": {
+                "combine-source-map": {
+                  "version": "0.3.0",
+                  "from": "combine-source-map@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+                  "dependencies": {
+                    "convert-source-map": {
+                      "version": "0.3.5",
+                      "from": "convert-source-map@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+                    },
+                    "inline-source-map": {
+                      "version": "0.3.1",
+                      "from": "inline-source-map@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                      "dependencies": {
+                        "source-map": {
+                          "version": "0.3.0",
+                          "from": "source-map@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "1.0.0",
+                              "from": "amdefine@>=0.0.4",
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "source-map@>=0.1.31 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
                 "JSONStream": {
                   "version": "0.6.4",
                   "from": "JSONStream@>=0.6.4 <0.7.0",
@@ -445,49 +852,6 @@
                   "version": "2.3.8",
                   "from": "through@>=2.3.4 <2.4.0",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                },
-                "combine-source-map": {
-                  "version": "0.3.0",
-                  "from": "combine-source-map@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
-                  "dependencies": {
-                    "inline-source-map": {
-                      "version": "0.3.1",
-                      "from": "inline-source-map@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
-                      "dependencies": {
-                        "source-map": {
-                          "version": "0.3.0",
-                          "from": "source-map@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
-                          "dependencies": {
-                            "amdefine": {
-                              "version": "1.0.0",
-                              "from": "amdefine@>=0.0.4",
-                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "convert-source-map": {
-                      "version": "0.3.5",
-                      "from": "convert-source-map@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
-                    },
-                    "source-map": {
-                      "version": "0.1.43",
-                      "from": "source-map@>=0.1.31 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "1.0.0",
-                          "from": "amdefine@>=0.0.4",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
                 }
               }
             },
@@ -627,11 +991,6 @@
               "from": "deps-sort@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-0.1.2.tgz",
               "dependencies": {
-                "through": {
-                  "version": "2.3.8",
-                  "from": "through@>=2.3.4 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                },
                 "JSONStream": {
                   "version": "0.6.4",
                   "from": "JSONStream@>=0.6.4 <0.7.0",
@@ -653,6 +1012,11 @@
                   "version": "0.0.10",
                   "from": "minimist@>=0.0.1 <0.1.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                },
+                "through": {
+                  "version": "2.3.8",
+                  "from": "through@>=2.3.4 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
@@ -661,16 +1025,21 @@
               "from": "derequire@>=0.8.0 <0.9.0",
               "resolved": "https://registry.npmjs.org/derequire/-/derequire-0.8.0.tgz",
               "dependencies": {
-                "estraverse": {
-                  "version": "1.5.1",
-                  "from": "estraverse@>=1.5.0 <1.6.0",
-                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
+                "esprima-fb": {
+                  "version": "3001.1.0-dev-harmony-fb",
+                  "from": "esprima-fb@>=3001.1.0-dev-harmony-fb <3002.0.0",
+                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
                 },
                 "esrefactor": {
                   "version": "0.1.0",
                   "from": "esrefactor@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/esrefactor/-/esrefactor-0.1.0.tgz",
                   "dependencies": {
+                    "escope": {
+                      "version": "0.0.16",
+                      "from": "escope@>=0.0.13 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/escope/-/escope-0.0.16.tgz"
+                    },
                     "esprima": {
                       "version": "1.0.4",
                       "from": "esprima@>=1.0.2 <1.1.0",
@@ -680,18 +1049,13 @@
                       "version": "0.0.4",
                       "from": "estraverse@>=0.0.4 <0.1.0",
                       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-0.0.4.tgz"
-                    },
-                    "escope": {
-                      "version": "0.0.16",
-                      "from": "escope@>=0.0.13 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/escope/-/escope-0.0.16.tgz"
                     }
                   }
                 },
-                "esprima-fb": {
-                  "version": "3001.1.0-dev-harmony-fb",
-                  "from": "esprima-fb@>=3001.1.0-dev-harmony-fb <3002.0.0",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+                "estraverse": {
+                  "version": "1.5.1",
+                  "from": "estraverse@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
                 }
               }
             },
@@ -804,28 +1168,28 @@
                 }
               }
             },
+            "JSONStream": {
+              "version": "0.8.4",
+              "from": "JSONStream@>=0.8.3 <0.9.0",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+              "dependencies": {
+                "jsonparse": {
+                  "version": "0.0.5",
+                  "from": "jsonparse@0.0.5",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                },
+                "through": {
+                  "version": "2.3.8",
+                  "from": "through@>=2.2.7 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                }
+              }
+            },
             "module-deps": {
               "version": "2.1.5",
               "from": "module-deps@>=2.1.1 <2.2.0",
               "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-2.1.5.tgz",
               "dependencies": {
-                "JSONStream": {
-                  "version": "0.7.4",
-                  "from": "JSONStream@>=0.7.1 <0.8.0",
-                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
-                  "dependencies": {
-                    "jsonparse": {
-                      "version": "0.0.5",
-                      "from": "jsonparse@0.0.5",
-                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
-                    },
-                    "through": {
-                      "version": "2.3.8",
-                      "from": "through@>=2.2.7 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                    }
-                  }
-                },
                 "browser-resolve": {
                   "version": "1.2.4",
                   "from": "browser-resolve@>=1.2.4 <1.3.0",
@@ -881,6 +1245,23 @@
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
                   "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
+                },
+                "JSONStream": {
+                  "version": "0.7.4",
+                  "from": "JSONStream@>=0.7.1 <0.8.0",
+                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+                  "dependencies": {
+                    "jsonparse": {
+                      "version": "0.0.5",
+                      "from": "jsonparse@0.0.5",
+                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                    },
+                    "through": {
+                      "version": "2.3.8",
+                      "from": "through@>=2.2.7 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                    }
+                  }
                 },
                 "minimist": {
                   "version": "0.0.10",
@@ -973,6 +1354,11 @@
               "version": "0.0.0",
               "from": "path-browserify@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+            },
+            "process": {
+              "version": "0.7.0",
+              "from": "process@>=0.7.0 <0.8.0",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.7.0.tgz"
             },
             "punycode": {
               "version": "1.2.4",
@@ -1121,18 +1507,6 @@
                       "from": "uglify-js@>=2.2.0 <2.3.0",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                       "dependencies": {
-                        "source-map": {
-                          "version": "0.1.43",
-                          "from": "source-map@>=0.1.7 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                          "dependencies": {
-                            "amdefine": {
-                              "version": "1.0.0",
-                              "from": "amdefine@>=0.0.4",
-                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                            }
-                          }
-                        },
                         "optimist": {
                           "version": "0.3.7",
                           "from": "optimist@>=0.3.5 <0.4.0",
@@ -1142,6 +1516,18 @@
                               "version": "0.0.3",
                               "from": "wordwrap@>=0.0.2 <0.1.0",
                               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                            }
+                          }
+                        },
+                        "source-map": {
+                          "version": "0.1.43",
+                          "from": "source-map@>=0.1.7 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "1.0.0",
+                              "from": "amdefine@>=0.0.4",
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                             }
                           }
                         }
@@ -1257,11 +1643,6 @@
               "version": "3.0.0",
               "from": "xtend@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
-            },
-            "process": {
-              "version": "0.7.0",
-              "from": "process@>=0.7.0 <0.8.0",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.7.0.tgz"
             }
           }
         },
@@ -1297,6 +1678,11 @@
           "from": "hogan.js@3.0.2",
           "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
           "dependencies": {
+            "mkdirp": {
+              "version": "0.3.0",
+              "from": "mkdirp@0.3.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+            },
             "nopt": {
               "version": "1.0.10",
               "from": "nopt@1.0.10",
@@ -1308,11 +1694,6 @@
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
-            },
-            "mkdirp": {
-              "version": "0.3.0",
-              "from": "mkdirp@0.3.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
             }
           }
         },
@@ -1421,11 +1802,6 @@
               "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
-            "typedarray": {
-              "version": "0.0.6",
-              "from": "typedarray@>=0.0.5 <0.1.0",
-              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-            },
             "readable-stream": {
               "version": "2.0.5",
               "from": "readable-stream@>=2.0.0 <2.1.0",
@@ -1457,6 +1833,11 @@
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "from": "typedarray@>=0.0.5 <0.1.0",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             }
           }
         },
@@ -1477,6 +1858,11 @@
           "from": "hogan.js@>=3.0.2 <4.0.0",
           "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
           "dependencies": {
+            "mkdirp": {
+              "version": "0.3.0",
+              "from": "mkdirp@0.3.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+            },
             "nopt": {
               "version": "1.0.10",
               "from": "nopt@1.0.10",
@@ -1488,11 +1874,6 @@
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
-            },
-            "mkdirp": {
-              "version": "0.3.0",
-              "from": "mkdirp@0.3.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
             }
           }
         },
@@ -1875,11 +2256,6 @@
                       "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
-                    "typedarray": {
-                      "version": "0.0.6",
-                      "from": "typedarray@>=0.0.5 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-                    },
                     "readable-stream": {
                       "version": "2.0.5",
                       "from": "readable-stream@>=2.0.0 <2.1.0",
@@ -1911,6 +2287,11 @@
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
+                    },
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "from": "typedarray@>=0.0.5 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     }
                   }
                 }
@@ -1921,6 +2302,11 @@
               "from": "hogan.js@>=3.0.2 <4.0.0",
               "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
               "dependencies": {
+                "mkdirp": {
+                  "version": "0.3.0",
+                  "from": "mkdirp@0.3.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+                },
                 "nopt": {
                   "version": "1.0.10",
                   "from": "nopt@1.0.10",
@@ -1932,11 +2318,6 @@
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
-                },
-                "mkdirp": {
-                  "version": "0.3.0",
-                  "from": "mkdirp@0.3.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
                 }
               }
             },
@@ -1995,16 +2376,21 @@
         }
       }
     },
+    "http-errors": {
+      "version": "1.3.1",
+      "from": "http-errors@>=1.3.1 <1.4.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+    },
+    "i": {
+      "version": "0.3.4",
+      "from": "i@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.4.tgz"
+    },
     "i18n-future": {
       "version": "0.2.0",
       "from": "i18n-future@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/i18n-future/-/i18n-future-0.2.0.tgz",
       "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "from": "lodash@>=3.7.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-        },
         "glob": {
           "version": "5.0.15",
           "from": "glob@>=5.0.5 <6.0.0",
@@ -2069,8 +2455,585 @@
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             }
           }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "from": "lodash@>=3.7.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
+    },
+    "inflight": {
+      "version": "1.0.4",
+      "from": "inflight@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz"
+    },
+    "inherits": {
+      "version": "2.0.1",
+      "from": "inherits@>=2.0.1 <2.1.0",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+    },
+    "inquirer": {
+      "version": "0.8.5",
+      "from": "inquirer@>=0.8.2 <0.9.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "1.1.1",
+          "from": "ansi-regex@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+        }
+      }
+    },
+    "ipaddr.js": {
+      "version": "1.0.5",
+      "from": "ipaddr.js@1.0.5",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
+    },
+    "is-absolute": {
+      "version": "0.1.7",
+      "from": "is-absolute@>=0.1.7 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz"
+    },
+    "is-my-json-valid": {
+      "version": "2.13.1",
+      "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "from": "is-property@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+    },
+    "is-relative": {
+      "version": "0.1.3",
+      "from": "is-relative@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "from": "isarray@0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+    },
+    "isexe": {
+      "version": "1.1.2",
+      "from": "isexe@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "from": "isstream@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+    },
+    "jade": {
+      "version": "0.26.3",
+      "from": "jade@0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "from": "commander@0.6.1"
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "from": "mkdirp@0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+        }
+      }
+    },
+    "js-yaml": {
+      "version": "3.5.3",
+      "from": "js-yaml@>=3.2.5 <4.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.3.tgz",
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.2",
+          "from": "esprima@>=2.6.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+        }
+      }
+    },
+    "jsonpointer": {
+      "version": "2.0.0",
+      "from": "jsonpointer@2.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+    },
+    "levn": {
+      "version": "0.2.5",
+      "from": "levn@>=0.2.5 <0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "from": "lodash@>=3.3.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz"
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+    },
+    "lodash._createassigner": {
+      "version": "3.1.1",
+      "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz"
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+    },
+    "lodash.assign": {
+      "version": "3.0.0",
+      "from": "lodash.assign@>=3.0.0 <3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz"
+    },
+    "lodash.isarguments": {
+      "version": "3.0.8",
+      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "from": "lodash.keys@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "from": "lodash.restparam@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+    },
+    "lolex": {
+      "version": "1.3.2",
+      "from": "lolex@1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz"
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "from": "lru-cache@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "from": "media-typer@0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "from": "merge-descriptors@1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+    },
+    "methods": {
+      "version": "1.1.2",
+      "from": "methods@>=1.1.2 <1.2.0",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+    },
+    "mime": {
+      "version": "1.3.4",
+      "from": "mime@1.3.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+    },
+    "mime-db": {
+      "version": "1.22.0",
+      "from": "mime-db@>=1.22.0 <1.23.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+    },
+    "mime-types": {
+      "version": "2.1.10",
+      "from": "mime-types@>=2.1.6 <2.2.0",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz"
+    },
+    "minimatch": {
+      "version": "2.0.10",
+      "from": "minimatch@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "from": "minimist@0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "from": "mkdirp@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+    },
+    "ms": {
+      "version": "0.7.1",
+      "from": "ms@0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+    },
+    "mute-stream": {
+      "version": "0.0.4",
+      "from": "mute-stream@0.0.4",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+    },
+    "ncp": {
+      "version": "0.4.2",
+      "from": "ncp@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
+    },
+    "negotiator": {
+      "version": "0.5.3",
+      "from": "negotiator@0.5.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+    },
+    "node-uuid": {
+      "version": "1.4.7",
+      "from": "node-uuid@>=1.4.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+    },
+    "object-assign": {
+      "version": "2.1.1",
+      "from": "object-assign@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "from": "on-finished@>=2.3.0 <2.4.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
+    },
+    "once": {
+      "version": "1.3.3",
+      "from": "once@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+    },
+    "optionator": {
+      "version": "0.5.0",
+      "from": "optionator@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz"
+    },
+    "os-shim": {
+      "version": "0.1.3",
+      "from": "os-shim@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
+    },
+    "parseurl": {
+      "version": "1.3.1",
+      "from": "parseurl@>=1.3.1 <1.4.0",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+    },
+    "path-is-absolute": {
+      "version": "1.0.0",
+      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "from": "path-to-regexp@0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+    },
+    "pathval": {
+      "version": "0.1.1",
+      "from": "pathval@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz"
+    },
+    "pkginfo": {
+      "version": "0.4.0",
+      "from": "pkginfo@>=0.0.0 <1.0.0",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.0.tgz"
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "from": "prelude-ls@>=1.1.1 <1.2.0",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+    },
+    "process-nextick-args": {
+      "version": "1.0.6",
+      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+    },
+    "prompt": {
+      "version": "0.2.14",
+      "from": "prompt@>=0.2.14 <0.3.0",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz"
+    },
+    "proxy-addr": {
+      "version": "1.0.10",
+      "from": "proxy-addr@>=1.0.10 <1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz"
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "from": "pseudomap@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+    },
+    "qs": {
+      "version": "4.0.0",
+      "from": "qs@4.0.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
+    },
+    "range-parser": {
+      "version": "1.0.3",
+      "from": "range-parser@>=1.0.3 <1.1.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
+    },
+    "read": {
+      "version": "1.0.7",
+      "from": "read@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz"
+    },
+    "readable-stream": {
+      "version": "2.0.5",
+      "from": "readable-stream@>=2.0.0 <2.1.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+    },
+    "readline2": {
+      "version": "0.1.1",
+      "from": "readline2@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "1.1.1",
+          "from": "ansi-regex@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+        },
+        "strip-ansi": {
+          "version": "2.0.1",
+          "from": "strip-ansi@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
+        }
+      }
+    },
+    "revalidator": {
+      "version": "0.1.8",
+      "from": "revalidator@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
+    },
+    "rimraf": {
+      "version": "2.5.2",
+      "from": "rimraf@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "7.0.0",
+          "from": "glob@>=7.0.0 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz"
+        }
+      }
+    },
+    "rx": {
+      "version": "2.5.3",
+      "from": "rx@>=2.4.3 <3.0.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz"
+    },
+    "samsam": {
+      "version": "1.1.2",
+      "from": "samsam@1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
+    },
+    "send": {
+      "version": "0.13.1",
+      "from": "send@0.13.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz"
+    },
+    "serve-static": {
+      "version": "1.10.2",
+      "from": "serve-static@>=1.10.2 <1.11.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz"
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "from": "sigmund@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+    },
+    "spawn-sync": {
+      "version": "1.0.13",
+      "from": "spawn-sync@1.0.13",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.13.tgz"
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "from": "sprintf-js@>=1.0.2 <1.1.0",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+    },
+    "stack-trace": {
+      "version": "0.0.9",
+      "from": "stack-trace@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+    },
+    "statuses": {
+      "version": "1.2.1",
+      "from": "statuses@>=1.2.1 <1.3.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "from": "string_decoder@>=0.10.0 <0.11.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "from": "strip-ansi@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "from": "strip-json-comments@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "from": "supports-color@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "from": "text-table@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+    },
+    "through": {
+      "version": "2.3.8",
+      "from": "through@>=2.3.6 <3.0.0",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "from": "type-check@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "from": "type-detect@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+    },
+    "type-is": {
+      "version": "1.6.12",
+      "from": "type-is@>=1.6.6 <1.7.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz"
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "from": "typedarray@>=0.0.5 <0.1.0",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "from": "unpipe@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+    },
+    "user-home": {
+      "version": "1.1.1",
+      "from": "user-home@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+    },
+    "util": {
+      "version": "0.10.3",
+      "from": "util@>=0.10.3 <1.0.0",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "from": "util-deprecate@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+    },
+    "utile": {
+      "version": "0.2.1",
+      "from": "utile@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz"
+    },
+    "utils-merge": {
+      "version": "1.0.0",
+      "from": "utils-merge@1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+    },
+    "vary": {
+      "version": "1.0.1",
+      "from": "vary@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
+    },
+    "vow": {
+      "version": "0.4.12",
+      "from": "vow@>=0.4.8 <0.5.0",
+      "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.12.tgz"
+    },
+    "vow-fs": {
+      "version": "0.3.4",
+      "from": "vow-fs@>=0.3.4 <0.4.0",
+      "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "4.5.3",
+          "from": "glob@>=4.3.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
+        }
+      }
+    },
+    "vow-queue": {
+      "version": "0.4.2",
+      "from": "vow-queue@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.2.tgz"
+    },
+    "which": {
+      "version": "1.1.2",
+      "from": "which@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.1.2.tgz"
+    },
+    "winston": {
+      "version": "0.8.3",
+      "from": "winston@>=0.8.0 <0.9.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+      "dependencies": {
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@>=0.6.0 <0.7.0"
+        },
+        "pkginfo": {
+          "version": "0.3.1",
+          "from": "pkginfo@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
+        }
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "from": "wordwrap@>=0.0.2 <0.1.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+    },
+    "wrappy": {
+      "version": "1.0.1",
+      "from": "wrappy@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+    },
+    "xml-escape": {
+      "version": "1.0.0",
+      "from": "xml-escape@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
+    },
+    "xmlbuilder": {
+      "version": "2.6.5",
+      "from": "xmlbuilder@>=2.6.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.5.tgz"
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "from": "xtend@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+    },
+    "yallist": {
+      "version": "2.0.0",
+      "from": "yallist@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "hof",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Home Office Forms (HOF) single package that bundles up a collection of packages used to create forms at the Home Office in node.js.",
   "main": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/UKHomeOffice/hof.git"
+  },
+  "scripts": {
+    "test": "NODE_ENV=test mocha",
+    "lint": "eslint .",
+    "style": "jscs **/*.js --config=./.jscsrc.json"
   },
   "keywords": [
     "forms",
@@ -19,6 +24,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/hof",
   "dependencies": {
+    "express": "^4.13.4",
     "hmpo-form-wizard": "^4.0.0",
     "hmpo-frontend-toolkit": "^2.0.0",
     "hmpo-govuk-template": "0.0.3",
@@ -27,13 +33,32 @@
     "hof-controllers": "0.1.1",
     "i18n-future": "^0.2.0"
   },
+  "devDependencies": {
+    "chai": "^3.0.0",
+    "eslint": "^0.23.0",
+    "eslint-plugin-filenames": "^0.1.1",
+    "eslint-plugin-mocha": "^0.2.2",
+    "eslint-plugin-one-variable-per-var": "0.0.3",
+    "jscs": "^1.13.1",
+    "mocha": "^2.2.5",
+    "node-mocks-http": "^1.5.1",
+    "pre-commit": "^1.0.10",
+    "sinomocha": "^0.2.4",
+    "sinon": "^1.15.3",
+    "sinon-chai": "^2.8.0"
+  },
+  "pre-commit": [
+    "lint",
+    "style",
+    "test"
+  ],
   "browser": {
     "hmpo-form-wizard": false,
     "hmpo-govuk-template": false,
     "hmpo-model": false,
     "hmpo-template-mixins": false,
     "i18n-future": false,
-    "i18n-lookup": false,
-    "hof-controllers": false
+    "hof-controllers": false,
+    "./lib/middleware.js": false
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,13 @@
+env:
+  mocha: true
+globals:
+  chai: true
+  expect: true
+  sinon: true
+  should: true
+rules:
+  func-names: 0
+  max-nested-callbacks: 0
+  no-unused-expressions: 0
+  no-process-env: 0
+  no-console: 0

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,9 @@
+'use strict';
+
+global.chai = require('chai').use(require('sinon-chai'));
+global.should = chai.should();
+global.sinon = require('sinon');
+require('sinomocha')();
+
+process.setMaxListeners(0);
+process.stdout.setMaxListeners(0);

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--require test/common.js
+--recursive
+--reporter spec

--- a/test/unit/lib/middleware.js
+++ b/test/unit/lib/middleware.js
@@ -1,0 +1,105 @@
+'use strict';
+
+var httpMock = require('node-mocks-http');
+
+describe('lib/middleware', function () {
+
+  var middleware = require('../../../lib/middleware');
+
+  describe('cookies', function () {
+    var req;
+    var res;
+
+    beforeEach(function () {
+      res = httpMock.createResponse({
+        eventEmitter: require('events').EventEmitter
+      });
+      middleware = require('../../../lib/middleware')({
+        'cookie-name': 'hof_cookie'
+      });
+    });
+
+    it('creates a route for /cookies-required', function () {
+      req = httpMock.createRequest({
+        method: 'GET',
+        url: '/cookies-required',
+      });
+
+      res.render = sinon.stub();
+
+      middleware.handle(req, res);
+
+      res.render.should.have.been.calledWith('cookies-required');
+    });
+
+    describe('cookie middleware (ensureCookie)', function () {
+
+      beforeEach(function () {
+        req = httpMock.createRequest({
+          method: 'GET',
+          url: '/my-hof-journey',
+        });
+
+        res.cookie = sinon.stub();
+
+        res.redirect = sinon.stub();
+      });
+
+      it('attempts to set a cookie if one is not available', function () {
+        middleware.handle(req, res);
+
+        res.cookie.should.have.been.calledWith('hof_cookie', '/my-hof-journey');
+      });
+
+      it('redirects to /check-cookies', function () {
+        middleware.handle(req, res);
+
+        res.redirect.should.have.been.calledWith('/check-cookies');
+      });
+
+    });
+
+    describe('/check-cookies', function () {
+
+      beforeEach(function () {
+        req = httpMock.createRequest({
+          method: 'GET',
+          url: '/check-cookies',
+        });
+
+        res.redirect = sinon.stub();
+      });
+
+      it('redirects to /cookies-required if no cookies are set', function () {
+        req.cookies = {};
+
+        middleware.handle(req, res);
+
+        res.redirect.should.have.been.calledWith('/cookies-required');
+      });
+
+      it('redirects to /cookies-required if no configured cookie is set', function () {
+        req.cookies = {
+          'hof-cookie-check': '/my-hof-journey'
+        };
+
+        middleware.handle(req, res);
+
+        res.redirect.should.have.been.calledWith('/cookies-required');
+      });
+
+      it('redirects to url set in the cookie', function () {
+        req.cookies = {
+          'hof_cookie': '/my-hof-journey'
+        };
+
+        middleware.handle(req, res);
+
+        res.redirect.should.have.been.calledWith('/my-hof-journey');
+      });
+
+    });
+
+  });
+
+});

--- a/test/unit/lib/middleware.js
+++ b/test/unit/lib/middleware.js
@@ -19,19 +19,6 @@ describe('lib/middleware', function () {
       });
     });
 
-    it('creates a route for /cookies-required', function () {
-      req = httpMock.createRequest({
-        method: 'GET',
-        url: '/cookies-required',
-      });
-
-      res.render = sinon.stub();
-
-      middleware.handle(req, res);
-
-      res.render.should.have.been.calledWith('cookies-required');
-    });
-
     describe('cookie middleware (ensureCookie)', function () {
 
       beforeEach(function () {
@@ -51,44 +38,58 @@ describe('lib/middleware', function () {
         res.cookie.should.have.been.calledWith('hof_cookie', '/my-hof-journey');
       });
 
-      it('redirects to /check-cookies', function () {
+      it('redirects to /cookies-required', function () {
         middleware.handle(req, res);
 
-        res.redirect.should.have.been.calledWith('/check-cookies');
+        res.redirect.should.have.been.calledWith('/cookies-required?location=' + encodeURIComponent('/my-hof-journey'));
       });
 
     });
 
-    describe('/check-cookies', function () {
+    describe('/cookies-required', function () {
 
       beforeEach(function () {
         req = httpMock.createRequest({
           method: 'GET',
-          url: '/check-cookies',
+          url: '/cookies-required',
+          query: {
+            location: '/my-hof-journey'
+          }
         });
 
         res.redirect = sinon.stub();
+        res.render = sinon.stub();
       });
 
-      it('redirects to /cookies-required if no cookies are set', function () {
+      it('renders cookies-required if no cookies are set', function () {
         req.cookies = {};
 
         middleware.handle(req, res);
 
-        res.redirect.should.have.been.calledWith('/cookies-required');
+        res.render.should.have.been.calledWith('cookies-required');
       });
 
-      it('redirects to /cookies-required if no configured cookie is set', function () {
+      it('renders cookies-required if no configured cookie is set', function () {
         req.cookies = {
           'hof-cookie-check': '/my-hof-journey'
         };
 
         middleware.handle(req, res);
 
-        res.redirect.should.have.been.calledWith('/cookies-required');
+        res.render.should.have.been.calledWith('cookies-required');
       });
 
-      it('redirects to url set in the cookie', function () {
+      it('renders cookies-required if cookie does not match query string param', function () {
+        req.cookies = {
+          'hof_cookie': '/HaX0r'
+        };
+
+        middleware.handle(req, res);
+
+        res.render.should.have.been.calledWith('cookies-required');
+      });
+
+      it('redirects to url set in the cookie and query string param', function () {
         req.cookies = {
           'hof_cookie': '/my-hof-journey'
         };


### PR DESCRIPTION
The name is quite generic as we will probably use this for other things in the future.

Will ensure that cookies are checked for on all routes other than '/cookies-required'

Defaults to 'hof-cookie-check' although this can be configured via the options

Usage:

``` js

app.use(require('hof').middleware({
  'cookie-name': 'cookie-name'
}));

```
