### PR TITLE
Use a default cookie name when non is provided

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -21,10 +21,10 @@ module.exports = function generateMiddleware(options) {
   });
 
   middleware.use(function ensureCookie(req, res, next) {
-    if (Object.keys(req.cookies).length && req.cookies[options['cookie-name']]) {
+    if (Object.keys(req.cookies).length && req.cookies[cookieName]) {
       next();
     } else {
-      res.cookie(options['cookie-name'], req.originalUrl);
+      res.cookie(cookieName, req.originalUrl);
       res.redirect('/cookies-required?location=' + encodeURIComponent(req.originalUrl));
     }
   });


### PR DESCRIPTION
Fixes a bug in which the middleware failed to set the correct cookie
when the user had to the cookie name to use.
