### PR TITLE
Simplify middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Home Office Forms (HOF) is a single package that bundles up a collection of modu
 
 ## What is it?
 
-HOF comprises the following modules.
+HOF provides the following which can be accessed through its properties.
 
  * [hmpo-form-wizard](https://github.com/UKHomeOffice/passports-form-wizard)
  * [hmpo-frontend-toolkit](https://github.com/UKHomeOffice/passports-frontend-toolkit)
@@ -17,9 +17,7 @@ HOF comprises the following modules.
  * [hmpo-template-mixins](https://github.com/UKHomeOffice/passports-template-mixins)
  * [hof-controllers](https://github.com/UKHomeOffice/hof-controllers)
  * [i18n-future](https://github.com/lennym/i18n-future)
- * [middleware](https://github.com/UKHomeOffice/hof/documentation/middleware.md)
-
-And each module is available as a property of `hof`
+ * [middleware](https://github.com/UKHomeOffice/hof/blob/master/documentation/middleware.md)
 
 ## Installation
 ```bash

--- a/documentation/middleware.md
+++ b/documentation/middleware.md
@@ -1,17 +1,28 @@
 # Middleware
 
-HOF exports a middleware as `middleware`, a small collection of routes and middlewares. Currently the middleware only adds support for enforcing that a cookie is set and if not redirecting to a /cookies-required page.
+HOF exports a middleware as `middleware`. Currently the middleware only
+adds support for testing whether cookies are supported in the client and
+raising an error when they are not.
 
 ## Usage
 
 ```js
 app.use(require('hof').middleware({
-  'cookie-name': 'my-application-cookie'
+  'cookie-name': 'my-application-cookie',
+  'param-name': 'my-query-param'
 }));
 ```
 
 This middleware must be declared before your other routes.
 
-When this middleware is used it will add one new route that you will need to create a template for:
+The `cookie-name` can be the same as your session cookie. (The
+middleware will not overwrite it.) Defaults to `hof-cookie-check`.
 
- * /cookies-required
+The `param-name` should be chosen so that it does not clash with names
+you are using elsewhere. In almost all cases the default value of
+`hof-cookie-check` will suffice.
+
+The error raised when cookies are not supported by the client can then
+be handled in you error handler by identifying it using its `code`
+property which will be set to `NO_COOKIES`.
+

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,33 +1,30 @@
 'use strict';
 
-var middleware = require('express').Router();
-
 module.exports = function generateMiddleware(options) {
+  var checkName = 'hof-cookie-check';
 
   options = options || {};
 
-  var cookieName = options['cookie-name'] || 'hof-cookie-check';
+  var cookieName = options['cookie-name'] || checkName;
+  var paramName = options['param-name'] || checkName;
 
-  middleware.get('/cookies-required', function checkCookie(req, res) {
-    var location = req.query.location;
-
-    if (Object.keys(req.cookies).length &&
-        req.cookies[cookieName] &&
-        req.cookies[cookieName] === location) {
-      res.redirect(location);
-    } else {
-      res.render('cookies-required');
-    }
-  });
-
-  middleware.use(function ensureCookie(req, res, next) {
-    if (Object.keys(req.cookies).length && req.cookies[cookieName]) {
+  var middleware = function testCookieSupport(req, res, next) {
+    if (Object.keys(req.cookies).length) {
+      // Cookies are supported; Continue
       next();
+    } else if (req.query[paramName] !== undefined) {
+      // Cookies are NOT supported; Raise an error
+      var err = new Error('Cookies required');
+
+      err.code = 'NO_COOKIES';
+
+      next(err, req, res, next);
     } else {
-      res.cookie(cookieName, req.originalUrl);
-      res.redirect('/cookies-required?location=' + encodeURIComponent(req.originalUrl));
+      // Test whether cookies are supported
+      res.cookie(cookieName, 1);
+      res.redirect(req.originalUrl + '?' + encodeURIComponent(paramName));
     }
-  });
+  };
 
   return middleware;
 };


### PR DESCRIPTION
Simplifies the middleware by removing both the hard-coded endpoint (in
favour of a query parameter) and the call to res.render (in favour of
simply raising an error to be handled later in the stack, as the
consuming application sees fit.
