### PR TITLE
Update hof to the latest version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ HOF provides the following which can be accessed through its properties.
  * [hmpo-template-mixins](https://github.com/UKHomeOffice/passports-template-mixins)
  * [hof-controllers](https://github.com/UKHomeOffice/hof-controllers)
  * [i18n-future](https://github.com/lennym/i18n-future)
- * [middleware](https://github.com/UKHomeOffice/hof/blob/master/documentation/middleware.md)
+ * [middleware](./documentation/middleware.md)
 
 ## Installation
 ```bash

--- a/documentation/middleware.md
+++ b/documentation/middleware.md
@@ -24,5 +24,5 @@ you are using elsewhere. In almost all cases the default value of
 
 The error raised when cookies are not supported by the client can then
 be handled in you error handler by identifying it using its `code`
-property which will be set to `NO_COOKIES`.
+property which will be set to `NO_COOKIES`. An example of handling this error can be found in the [hof-example-form](https://github.com/UKHomeOffice/hof-example-form/blob/master/errors/index.js).
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "hof",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "dependencies": {
     "express": {
       "version": "4.13.4",
@@ -240,9 +240,9 @@
       }
     },
     "hmpo-form-wizard": {
-      "version": "4.1.0",
+      "version": "4.2.0",
       "from": "hmpo-form-wizard@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/hmpo-form-wizard/-/hmpo-form-wizard-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/hmpo-form-wizard/-/hmpo-form-wizard-4.2.0.tgz",
       "dependencies": {
         "csrf": {
           "version": "2.0.7",
@@ -296,9 +296,9 @@
           "resolved": "https://registry.npmjs.org/hmpo-form-controller/-/hmpo-form-controller-0.5.0.tgz",
           "dependencies": {
             "moment": {
-              "version": "2.11.2",
+              "version": "2.12.0",
               "from": "moment@>=2.9.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
             }
           }
         },
@@ -314,7 +314,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "typedarray": {
@@ -1204,16 +1204,9 @@
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "decamelize": {
-                          "version": "1.1.2",
+                          "version": "1.2.0",
                           "from": "decamelize@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                          "dependencies": {
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            }
-                          }
+                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                         },
                         "window-size": {
                           "version": "0.1.0",
@@ -1289,7 +1282,7 @@
         },
         "underscore": {
           "version": "1.8.3",
-          "from": "underscore@>=1.8.3 <2.0.0",
+          "from": "underscore@>=1.7.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
         }
       }
@@ -1509,9 +1502,9 @@
           }
         },
         "moment": {
-          "version": "2.11.2",
+          "version": "2.12.0",
           "from": "moment@>=2.9.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
         },
         "underscore": {
           "version": "1.8.3",
@@ -1750,9 +1743,9 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "moment": {
-          "version": "2.11.2",
+          "version": "2.12.0",
           "from": "moment@>=2.9.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
         },
         "moment-business": {
           "version": "2.0.0",
@@ -1794,7 +1787,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.7.0 <4.0.0",
+          "from": "lodash@>=3.10.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "glob": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Home Office Forms (HOF) single package that bundles up a collection of packages used to create forms at the Home Office in node.js.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This release includes a refactor of the hof.middleware as the previous release dictated application routes which we felt was undesirable.
