### PR TITLE
Ensure req.cookies available before we get it's keys.

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -9,7 +9,7 @@ module.exports = function generateMiddleware(options) {
   var paramName = options['param-name'] || checkName;
 
   var middleware = function testCookieSupport(req, res, next) {
-    if (Object.keys(req.cookies).length) {
+    if (req.cookies && Object.keys(req.cookies).length) {
       // Cookies are supported; Continue
       next();
     } else if (req.query[paramName] !== undefined) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "hof",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "dependencies": {
     "express": {
       "version": "4.13.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Home Office Forms (HOF) single package that bundles up a collection of packages used to create forms at the Home Office in node.js.",
   "main": "index.js",
   "repository": {

--- a/test/unit/lib/middleware.js
+++ b/test/unit/lib/middleware.js
@@ -57,6 +57,21 @@ describe('lib/middleware', function () {
       });
 
       it('raises an error when a cookie could not be set', function () {
+        req.cookies = undefined;
+        req.query = {
+          'hof_param': true
+        };
+
+        middleware(req, res, next);
+
+        var err = new Error();
+
+        err.code = 'NO_COOKIES';
+
+        next.should.have.been.calledWith(err, req, res, next);
+      });
+
+      it('raises an error when a cookie could not be set', function () {
         req.cookies = {};
         req.query = {
           'hof_param': true


### PR DESCRIPTION
There are instances where req.cookies is undefined. This is defensive against this.
