### PR TITLE
Update hof to v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,19 @@
 # HOF ChangeLog
 
+## 2016-03-14, Version 6.0.0 (Stable), @easternbloc
+* **hmpo-frontend-toolkit**: Upgraded to 3.0.1
+* **hmpo-form-wizard**: Upgraded to 4.3.0
+
+## 2016-03-11, Version 5.0.0 (Stable), @easternbloc
+* **HOF-Middleware**: Changed to only return an error instead of deciding making a cookie route
+
 ## 2016-03-04, Version 4.0.0 (Stable), @easternbloc
-
-### Notable changes
-
 * **hmpo-form-wizard**: Upgraded to 4.1.0
 * **hmpo-template-mixins**: Upgraded to 4.0.0
 
-# HOF ChangeLog
-
 ## 2016-03-03, Version 3.2.0 (Stable), @easternbloc
-
-### Notable changes
-
 * **HOF-Middleware**: Added support for cookie checking on all routes other than /cookies-required
 
 ## 2015-11-25, Version 1.1.0 (Stable), @Joechapman
-
-### Notable changes
-
 * **HOF-Controllers**: Added support for `forks` when defined in `steps.js`
   - [Forking](https://github.com/UKHomeOffice/hof-controllers#handles-journey-forking)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "hof",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "dependencies": {
     "express": {
       "version": "4.13.4",
@@ -183,7 +183,7 @@
             },
             "mime": {
               "version": "1.3.4",
-              "from": "mime@1.3.4",
+              "from": "mime@>=1.3.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "ms": {
@@ -240,9 +240,9 @@
       }
     },
     "hmpo-form-wizard": {
-      "version": "4.2.0",
-      "from": "hmpo-form-wizard@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/hmpo-form-wizard/-/hmpo-form-wizard-4.2.0.tgz",
+      "version": "4.3.0",
+      "from": "hmpo-form-wizard@>=4.3.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/hmpo-form-wizard/-/hmpo-form-wizard-4.3.0.tgz",
       "dependencies": {
         "csrf": {
           "version": "2.0.7",
@@ -291,9 +291,9 @@
           }
         },
         "hmpo-form-controller": {
-          "version": "0.5.0",
-          "from": "hmpo-form-controller@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/hmpo-form-controller/-/hmpo-form-controller-0.5.0.tgz",
+          "version": "0.6.0",
+          "from": "hmpo-form-controller@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/hmpo-form-controller/-/hmpo-form-controller-0.6.0.tgz",
           "dependencies": {
             "moment": {
               "version": "2.12.0",
@@ -314,7 +314,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "typedarray": {
@@ -323,9 +323,9 @@
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
-                  "version": "2.0.5",
+                  "version": "2.0.6",
                   "from": "readable-stream@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -333,9 +333,9 @@
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
@@ -395,9 +395,9 @@
       }
     },
     "hmpo-frontend-toolkit": {
-      "version": "2.0.0",
-      "from": "hmpo-frontend-toolkit@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/hmpo-frontend-toolkit/-/hmpo-frontend-toolkit-2.0.0.tgz",
+      "version": "3.0.1",
+      "from": "hmpo-frontend-toolkit@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/hmpo-frontend-toolkit/-/hmpo-frontend-toolkit-3.0.1.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.2",
@@ -663,7 +663,7 @@
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "from": "minimist@>=0.0.7 <0.1.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
@@ -1282,7 +1282,7 @@
         },
         "underscore": {
           "version": "1.8.3",
-          "from": "underscore@>=1.7.0 <2.0.0",
+          "from": "underscore@>=1.8.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
         }
       }
@@ -1412,9 +1412,9 @@
       }
     },
     "hmpo-model": {
-      "version": "0.2.0",
-      "from": "hmpo-model@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/hmpo-model/-/hmpo-model-0.2.0.tgz",
+      "version": "0.3.0",
+      "from": "hmpo-model@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/hmpo-model/-/hmpo-model-0.3.0.tgz",
       "dependencies": {
         "concat-stream": {
           "version": "1.5.1",
@@ -1432,9 +1432,9 @@
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
-              "version": "2.0.5",
+              "version": "2.0.6",
               "from": "readable-stream@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
@@ -1442,9 +1442,9 @@
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "version": "1.0.0",
+                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
@@ -1479,7 +1479,7 @@
       "dependencies": {
         "hogan.js": {
           "version": "3.0.2",
-          "from": "hogan.js@3.0.2",
+          "from": "hogan.js@>=3.0.2 <4.0.0",
           "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
           "dependencies": {
             "nopt": {
@@ -1503,7 +1503,7 @@
         },
         "moment": {
           "version": "2.12.0",
-          "from": "moment@>=2.9.0 <3.0.0",
+          "from": "moment@>=2.10.3 <3.0.0",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
         },
         "underscore": {
@@ -1666,9 +1666,9 @@
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
-                      "version": "2.0.5",
+                      "version": "2.0.6",
                       "from": "readable-stream@>=2.0.0 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -1676,9 +1676,9 @@
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "version": "1.0.0",
+                          "from": "isarray@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.6",
@@ -1744,7 +1744,7 @@
         },
         "moment": {
           "version": "2.12.0",
-          "from": "moment@>=2.9.0 <3.0.0",
+          "from": "moment@>=2.10.3 <3.0.0",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
         },
         "moment-business": {
@@ -1787,7 +1787,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.10.1 <4.0.0",
+          "from": "lodash@>=3.7.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "glob": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Home Office Forms (HOF) single package that bundles up a collection of packages used to create forms at the Home Office in node.js.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "express": "^4.13.4",
     "hmpo-form-wizard": "^4.3.0",
-    "hmpo-frontend-toolkit": "^3.0.0",
+    "hmpo-frontend-toolkit": "^3.0.1",
     "hmpo-govuk-template": "0.0.3",
     "hmpo-model": "^0.3.0",
     "hmpo-template-mixins": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   "homepage": "https://github.com/UKHomeOffice/hof",
   "dependencies": {
     "express": "^4.13.4",
-    "hmpo-form-wizard": "^4.1.0",
-    "hmpo-frontend-toolkit": "^2.0.0",
+    "hmpo-form-wizard": "^4.3.0",
+    "hmpo-frontend-toolkit": "^3.0.0",
     "hmpo-govuk-template": "0.0.3",
-    "hmpo-model": "^0.2.0",
+    "hmpo-model": "^0.3.0",
     "hmpo-template-mixins": "^4.0.0",
     "hof-controllers": "0.1.1",
     "i18n-future": "^0.2.0"


### PR DESCRIPTION
Includes a major version bump of frontend toolkit

This also fixes some ie8 issues in the frontend toolkit
