### PR TITLE
Removed 0.12 from the build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "5"
+  - "6"
 
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "7.0.0",
   "description": "Home Office Forms (HOF) single package that bundles up a collection of packages used to create forms at the Home Office in node.js.",
   "main": "index.js",
+  "engines" : { "node" : ">=4.0.0" },
   "repository": {
     "type": "git",
     "url": "https://github.com/UKHomeOffice/hof.git"


### PR DESCRIPTION
Added engines to package to ensure we warn for < 4 node
