### PR TITLE
Don't bundle hof-middleware into client-side js

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "hmpo-template-mixins": false,
     "i18n-future": false,
     "hof-controllers": false,
-    "hof-middleware.js": false
+    "hof-middleware": false
   }
 }


### PR DESCRIPTION
Fixes a bug in which hof-middleware was being bundled into the
client-side javascript. This was causing problems in phantomjs and,
presumably, any other browsers that don't support ES6.
