### PR TITLE
New release of hof for 7.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # HOF ChangeLog
 
+## 2016-05-04, Version 7.0.1 (Stable), @easternbloc
+Fixes browserify bug (a backend module was not being removed from the frontend)
+
 ## 2016-05-03, Version 7.0.0 (Stable), @easternbloc
 * **hof-controllers**: Upgraded to 0.4.0
 * **hmpo-model**: 0.4.0

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "hof",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "dependencies": {
     "hmpo-form-wizard": {
       "version": "4.3.0",
@@ -302,7 +302,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "typedarray": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Home Office Forms (HOF) single package that bundles up a collection of packages used to create forms at the Home Office in node.js.",
   "main": "index.js",
   "engines" : { "node" : ">=4.0.0" },


### PR DESCRIPTION
This fixes a bug in our package json that meant browserify would bundle the hof-middleware which was a backend module (and es6) causing errors in some browsers
